### PR TITLE
Created quiz and quizResponse database models and routes

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ const cors = require('cors')
 const PORT = 3000
 const authRoutes = require('./routes/auth.js')
 const userRoutes = require('./routes/UserRoutes.js')
+const quizRoutes = require('./routes/QuizRoutes.js')
 const session = require('express-session')
 
 app.use(cors({
@@ -22,6 +23,7 @@ app.use(session({
 
 app.use('/auth', authRoutes)
 app.use('/user', userRoutes)
+app.use('/quiz', quizRoutes)
 
 app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`)

--- a/server/prisma/migrations/20250701000009_init_quiz_and_quiz_response_tables/migration.sql
+++ b/server/prisma/migrations/20250701000009_init_quiz_and_quiz_response_tables/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "quizzes" (
+    "id" INTEGER NOT NULL,
+
+    CONSTRAINT "quizzes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "quizResponses" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "question_id" INTEGER NOT NULL,
+    "question" TEXT NOT NULL,
+    "question_trait" TEXT NOT NULL,
+    "response" INTEGER NOT NULL,
+
+    CONSTRAINT "quizResponses_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "quizzes" ADD CONSTRAINT "quizzes_id_fkey" FOREIGN KEY ("id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "quizResponses" ADD CONSTRAINT "quizResponses_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "quizzes"("id") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -20,6 +20,27 @@ model User {
   password              String
   profile_picture       Bytes?         
   created_at            DateTime       @default(now())
+  personality_quiz      Quiz? 
 
   @@map("users")
+}
+
+model Quiz {
+  id               Int              @id 
+  quiz_responses   QuizResponse[]
+  user             User             @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: NoAction) 
+  
+  @@map("quizzes")
+}
+
+model QuizResponse {
+  id               Int              @id @default(autoincrement())
+  user_id          Int
+  question_id      Int
+  question         String
+  question_trait   String
+  response         Int
+  quiz             Quiz             @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@map("quizResponses")
 }

--- a/server/routes/QuizRoutes.js
+++ b/server/routes/QuizRoutes.js
@@ -1,0 +1,35 @@
+const express = require('express')
+const bcrypt = require('bcrypt')
+const { PrismaClient } = require('@prisma/client')
+const router = express.Router()
+const prisma = new PrismaClient();
+
+router.post('/', async (req, res) => {
+    const { id } = req.body
+    const newQuizData = await prisma.quiz.create({
+        data: {
+            id,
+        }
+    })
+    res.json(newQuizData);
+})
+
+router.post('/responses', async (req, res) => {
+    if (!req.body.response) {
+        return res.status(400).send('Response is required.')
+    }
+    const { id, user_id, question_id, question, question_trait, response } = req.body
+    const newResponseData = await prisma.quizResponse.create({
+        data: {
+        id,
+        user_id,
+        question_id,
+        question,
+        question_trait,
+        response
+        }
+    })
+    res.json(newResponseData);
+})
+
+module.exports = router


### PR DESCRIPTION
## Description

- Creates the Quiz and QuizResponse database models.
- Implements the POST routes for creating a new quiz and a new quiz response.
- In the next PR, I will use these routes in my client to create a new quiz when the user signs up and save each quiz response in the database.

## Milestones
This works towards Milestone 4, which is that the user can complete a personality quiz.

## Resources

## Test Plan
<img width="1728" alt="Screenshot 2025-07-01 at 10 15 50 AM" src="https://github.com/user-attachments/assets/da7ba334-8949-4869-a930-357585791c5d" />

I tested both POST routes using Insomnia to ensure that the data was being properly passed through and stored in the database.