### PR TITLE
Update Calendar to Week View Functionality

### DIFF
--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -6,6 +6,9 @@ import "react-big-calendar/lib/css/react-big-calendar.css";
 import EventPopup from "./EventPopup"; 
 
 const localizer = momentLocalizer(moment);
+const DEFAULT_YEAR = 2025;
+const DEFAULT_MONTH = 5;
+const DEFAULT_DAY = 1;
 
 const Calendar = () => {
     const [events, setEvents] = useState([]);
@@ -51,6 +54,11 @@ const Calendar = () => {
         setSelectedEvent(null);
     }
 
+    const formats = {
+        dayFormat: (date, culture, localizer) =>
+            localizer.format(date, 'dddd', culture),
+    }
+
     return (
         <>
             <div className="calendar">
@@ -59,11 +67,16 @@ const Calendar = () => {
                     selectable
                     localizer={localizer}
                     events={events}
+                    defaultView="week"
+                    views={["week"]}
+                    toolbar={false}
                     startAccessor="start"
                     endAccessor="end"
+                    date={new Date(DEFAULT_YEAR, DEFAULT_MONTH, DEFAULT_DAY)}
                     onSelectSlot={handleSelectSlot}
                     onSelectEvent={handleSelectEvent}
                     eventPropGetter={eventPropGetter}
+                    formats={formats}
                 />
             </div>
             {isOpenEvent && (

--- a/client/src/components/PersonalityQuiz.jsx
+++ b/client/src/components/PersonalityQuiz.jsx
@@ -44,7 +44,7 @@ const PersonalityQuiz = () => {
             response: sliderValue
         }
         const newResponse = await fetchData("quiz/responses/", "POST", {"Content-Type": "application/json"}, "same-origin", JSON.stringify(newResponseData));
-        if (currentObject.id >= 10){
+        if (currentObject.id >= PersonalityQuestions.length){
             navigate('/calendar');
         }
     }

--- a/client/src/data/WeekDays.js
+++ b/client/src/data/WeekDays.js
@@ -1,0 +1,11 @@
+const WeekDays = {
+    Sunday: 1,
+    Monday: 2,
+    Tuesday: 3,
+    Wednesday: 4,
+    Thursday: 5,
+    Friday: 6,
+    Saturday: 7,
+}
+
+export default WeekDays;


### PR DESCRIPTION
## Description

- Updates the calendar to only display the Week View and day names (Monday, Tuesday, Wednesday, etc.), instead of also displaying the specific month, date, and year.
- Updates edit event functionality so that the old event is deleted when the updated one is created.
- Replaces all magic numbers with constant variables to improve code clarity.
- In the next PR, I will save the user’s availability to the database so that it can be used for the availability algorithm later on.

## Milestones
This works towards Milestone 5, which is that the user can input their class schedule/availability.

## Resources

## Test Plan

https://github.com/user-attachments/assets/7f32763b-6973-44c1-9f95-1b864522e3ad


Besides testing basic functionality and ensuring that events were created at the right day and time, I also tested these corner cases:

- Edited an event’s title and time to ensure that it is properly updated.
- Created an event that lasts all day to ensure that it appears in the All Day section at the top of the calendar.
- Clicked all blank cells and existing event cells to ensure that the correct modal pops up: either “Add Class” or “Edit Class”.
- Created 4+ events that all overlap to ensure that they are all visibly displayed and in the correct time slots.
- Left the Class Name, Start, and End input fields empty, alternating between which is empty, to ensure that the user will get an error message if they don’t fill out all three input fields.