### PR TITLE
Update storage of events in the database

### DIFF
--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Calendar as ReactBigCalendar , momentLocalizer } from "react-big-calendar";
 import moment from "moment";
 import '../styles.css';
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import EventPopup from "./EventPopup"; 
 import { useUser } from "../contexts/UserContext";
+import WeekDays from "../data/WeekDays";
 
 const localizer = momentLocalizer(moment);
 const DEFAULT_YEAR = 2025;
@@ -17,6 +18,7 @@ const Calendar = () => {
     const [selectedDate, setSelectedDate] = useState(null);
     const [isOpenEvent, setIsOpenEvent] = useState(false);
     const [selectedEvent, setSelectedEvent] = useState(null);
+    const [eventId, setEventId] = useState();
 
     const eventPropGetter = (event) => {
         const backgroundColor = '#068484';
@@ -38,7 +40,8 @@ const Calendar = () => {
             if (!response.ok){
                 throw new Error('Not able to fetch data.')
             }
-            return response;
+            const data = await response.json();
+            return data;
         }
         catch {
             console.log("Error fetching data.")
@@ -58,6 +61,8 @@ const Calendar = () => {
     }
 
     const handleSaveEvent = (eventData) => {
+        const eventExists = Boolean(eventData.id);
+
         if (eventData.id) {
             setEvents((prev) =>
                 prev.map((ev) => (ev.id === eventData.id ? eventData : ev))
@@ -69,27 +74,58 @@ const Calendar = () => {
             }
             setEvents((prev) => [...prev, newEvent]);
         }
-        storeBusyTime(eventData);
+        storeBusyTime(eventData, eventExists);
         setIsOpenEvent(false);
         setSelectedDate(null);
         setSelectedEvent(null);
     }
 
-    const storeBusyTime = async (eventData) => {
+    const storeBusyTime = async (eventData, eventExists) => {
+        const busyTimeEndpoint = eventExists ? `availability/busyTime/${eventId}/` : "availability/busyTime/";
+        const busyTimeMethod = eventExists ? "PUT" : "POST";
         const newBusyTimeData = {
             user_id: user.id,
             day_of_week: eventData.start.toLocaleDateString('en-US', { weekday: 'long' }),
             start_time: eventData.start.toLocaleTimeString(),
-            end_time: eventData.end.toLocaleTimeString()
-
+            end_time: eventData.end.toLocaleTimeString(),
+            class_name: eventData.title
         }
-        const newBusyTime = await fetchData("availability/busyTime/", "POST", {"Content-Type": "application/json"}, "same-origin", JSON.stringify(newBusyTimeData));
+        const newBusyTime = await fetchData(busyTimeEndpoint, busyTimeMethod, {"Content-Type": "application/json"}, "same-origin", JSON.stringify(newBusyTimeData));
+        setEventId(newBusyTime.id);
+    }
+
+    const fetchEvents = async () => {
+        if (user){
+            const userEvents = await fetchData(`availability/busyTime/${user.id}`, "GET", {"Content-Type": "application/json"});
+            const formattedEvents = userEvents.map(e => {
+                const dayOfWeek = WeekDays[e.day_of_week];
+                const initialDate = new Date(DEFAULT_YEAR, DEFAULT_MONTH, dayOfWeek)
+                const [startHour, startMinute] = e.start_time.split(":");
+                const [endHour, endMinute] = e.end_time.split(":");
+                const startDate = new Date(initialDate);
+                startDate.setHours(startHour, startMinute);
+                const endDate = new Date(initialDate);
+                endDate.setHours(endHour, endMinute);
+
+                return {
+                    id: e.id,
+                    title: e.class_name,
+                    start: startDate,
+                    end: endDate,
+                }
+            })
+            setEvents(formattedEvents);
+        }
     }
 
     const formats = {
         dayFormat: (date, culture, localizer) =>
             localizer.format(date, 'dddd', culture),
     }
+
+    useEffect(() => {
+        fetchEvents();
+    }, [user])
 
     return (
         <>

--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -106,6 +106,7 @@ const Calendar = () => {
                 startDate.setHours(startHour, startMinute);
                 const endDate = new Date(initialDate);
                 endDate.setHours(endHour, endMinute);
+                setEventId(e.id);
 
                 return {
                     id: e.id,

--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -86,8 +86,8 @@ const Calendar = () => {
         const newBusyTimeData = {
             user_id: user.id,
             day_of_week: eventData.start.toLocaleDateString('en-US', { weekday: 'long' }),
-            start_time: eventData.start.toLocaleTimeString(),
-            end_time: eventData.end.toLocaleTimeString(),
+            start_time: eventData.start.toLocaleTimeString('en-US', { hour12: false }),
+            end_time: eventData.end.toLocaleTimeString('en-US', { hour12: false }),
             class_name: eventData.title
         }
         const newBusyTime = await fetchData(busyTimeEndpoint, busyTimeMethod, {"Content-Type": "application/json"}, "same-origin", JSON.stringify(newBusyTimeData));

--- a/client/src/pages/CalendarPage.jsx
+++ b/client/src/pages/CalendarPage.jsx
@@ -9,7 +9,7 @@ const CalendarPage = () => {
                     <h1>Study Match</h1>
                 </div>
             </div>
-            <div className="page-header">Availability</div>
+            <div className="page-header">Class Schedule</div>
             <p>Please input the classes you're taking, along with their respective times and days.</p>
             <Calendar />
             <Footer />

--- a/server/prisma/migrations/20250705004800_update_busy_time_table/migration.sql
+++ b/server/prisma/migrations/20250705004800_update_busy_time_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "busyTime" ADD COLUMN     "class_name" TEXT;

--- a/server/prisma/migrations/20250705004841_update_busy_time_table/migration.sql
+++ b/server/prisma/migrations/20250705004841_update_busy_time_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `class_name` on table `busyTime` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "busyTime" ALTER COLUMN "class_name" SET NOT NULL;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -59,7 +59,8 @@ model BusyTime {
   user_id          Int
   day_of_week      String
   start_time       String         
-  end_time         String         
+  end_time         String
+  class_name       String         
   busy_times       BusyTimes        @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@map("busyTime")

--- a/server/routes/AvailabilityRoutes.js
+++ b/server/routes/AvailabilityRoutes.js
@@ -5,7 +5,7 @@ const router = express.Router()
 const prisma = new PrismaClient();
 
 router.post('/', async (req, res) => {
-    const { id } = req.body
+    const {id} = req.body
     const newBusyTimeData = await prisma.busyTimes.create({
         data: {
             id,
@@ -15,7 +15,7 @@ router.post('/', async (req, res) => {
 })
 
 router.post('/busyTime', async (req, res) => {
-    const { id, user_id, day_of_week, start_time, end_time } = req.body
+    const {id, user_id, day_of_week, start_time, end_time, class_name} = req.body
     const newBusyTimeData = await prisma.busyTime.create({
         data: {
             id,
@@ -23,9 +23,35 @@ router.post('/busyTime', async (req, res) => {
             day_of_week,
             start_time,
             end_time,
+            class_name,
         }
     })
     res.json(newBusyTimeData);
+})
+
+router.put('/busyTime/:id', async (req, res) => {
+    const id = parseInt(req.params.id);
+    const {user_id, day_of_week, start_time, end_time, class_name} = req.body
+    const newBusyTimeData = await prisma.busyTime.update({
+        where: {id: parseInt(id)},
+        data: {
+            id,
+            user_id,
+            day_of_week,
+            start_time,
+            end_time,
+            class_name,
+        }
+    })
+    res.json(newBusyTimeData);
+})
+
+router.get('/busyTime/:userId', async (req, res) => {
+    const userId = parseInt(req.params.userId)
+    const busyTimes = await prisma.busyTime.findMany({
+        where: {user_id: parseInt(userId)},
+    });
+    res.json(busyTimes);
 })
 
 module.exports = router


### PR DESCRIPTION
## Description

- Updates edit event functionality so that only the most updated event is stored in the database, not both the updated and old events.
- Creates a class_name column in the BusyTime table to store the name of each class the user inputs.
- Fetches the event data from the database so that the events appear on the calendar even if the user refreshes the page.
- Stores start_time and end_time in military time in order to easily fetch and work with the time data.
- In the next PR, I will implement a dropdown of class names for the user to choose their class when creating a new event on the calendar.

## Milestones
This works towards Milestone 5, which is that the user can input class schedule/availability.

## Resources

## Test Plan

https://github.com/user-attachments/assets/d2ed46cb-3346-4441-898d-f87430f631ed


Besides testing basic functionality, these are the corner cases I tested:
- Created events in the morning, afternoon, from morning to afternoon, and all day to make sure they were all properly stored and fetched after refreshing the page.
- Edited events multiple times to ensure that only the most updated event will remain stored in the database.
- Created an event, refreshed the page, and then edited the event to ensure that the event was properly displayed on the screen and updated in the database even after the app is reloaded.