### PR TITLE
Calculate user free time slots

### DIFF
--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -6,6 +6,7 @@ import "react-big-calendar/lib/css/react-big-calendar.css";
 import EventPopup from "./EventPopup"; 
 import { useUser } from "../contexts/UserContext";
 import WeekDays from "../data/WeekDays";
+import MatchByAvailability from "../utils/MatchByAvailability";
 
 const localizer = momentLocalizer(moment);
 const DEFAULT_YEAR = 2025;
@@ -19,6 +20,7 @@ const Calendar = () => {
     const [isOpenEvent, setIsOpenEvent] = useState(false);
     const [selectedEvent, setSelectedEvent] = useState(null);
     const [eventId, setEventId] = useState();
+    const [busyTimes, setBusyTimes] = useState([]);
 
     const eventPropGetter = (event) => {
         const backgroundColor = '#068484';
@@ -98,6 +100,7 @@ const Calendar = () => {
     const fetchEvents = async () => {
         if (user){
             const userEvents = await fetchData(`availability/busyTime/${user.id}`, "GET", {"Content-Type": "application/json"});
+            setBusyTimes(userEvents);
             const formattedEvents = userEvents.map(e => {
                 const dayOfWeek = e.day_of_week;
                 const initialDate = new Date(DEFAULT_YEAR, DEFAULT_MONTH, dayOfWeek)
@@ -129,6 +132,12 @@ const Calendar = () => {
         fetchEvents();
     }, [user])
 
+    const matchByAvailability = () => {
+        if (busyTimes){
+            MatchByAvailability(busyTimes);
+        }
+    }
+
     return (
         <>
             <div className="calendar">
@@ -159,6 +168,7 @@ const Calendar = () => {
                     fetchData={fetchData}
                 />
             )}
+            <button className="buttons" id='submit-availability-button' onClick={matchByAvailability}>Submit Availability</button>
         </>
     )
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -298,3 +298,12 @@ button:focus-visible {
 #add-class-button {
     margin-bottom: 10px;
 }
+
+.calendar {
+    margin-top: 40px;
+    margin-bottom: 40px;
+}
+
+#submit-availability-button {
+    margin-bottom: 100px;
+}

--- a/client/src/utils/MatchByAvailability.jsx
+++ b/client/src/utils/MatchByAvailability.jsx
@@ -1,0 +1,89 @@
+const sortBusyTimes = (busyTimes) => {
+    const busyTimesPerDay = [];
+
+    for (const busyTime of busyTimes){
+        const day_of_week = busyTime.day_of_week;
+        if (!busyTimesPerDay[day_of_week]){
+            busyTimesPerDay[day_of_week] = [];
+        }
+        busyTimesPerDay[day_of_week].push(busyTime);
+    }
+    return busyTimesPerDay;
+}
+
+const getFreeTimes = (busyTimesPerDay) => {
+    const MINUTES_IN_HOUR = 60;
+    const STUDY_GROUPS_START = 8 * 60;
+    const STUDY_GROUPS_END = 20 * 60;
+    const DAYS_IN_WEEK = 7;
+    const freeTimes = [];
+    let currentEndTime = STUDY_GROUPS_END;
+    const mergedOverlapBusyTimes = [];
+
+    const stringToTime = (timeString) => {
+        const [hours, minutes] = timeString.split(":").map(Number);
+        return hours * MINUTES_IN_HOUR + minutes;
+    }
+
+    const busyTimesPerDayInMins = busyTimesPerDay.map((busyTimes) => {
+        return busyTimes.map((busyTime) => ({
+            day_of_week: busyTime.day_of_week,
+            start_time: stringToTime(busyTime.start_time),
+            end_time: stringToTime(busyTime.end_time),
+        })).sort((a,b) => b.start_time - a.start_time)
+    })
+
+    for (const day of busyTimesPerDayInMins){
+        if(!day){
+            continue;
+        }
+        mergedOverlapBusyTimes[day[0].day_of_week] = [];
+        for (let i = 0; i < day.length; i++){
+            if ((day[i+1]) && day[i].start_time < day[i+1].end_time){
+                mergedOverlapBusyTimes[day[0].day_of_week].push({start_time: day[i+1].start_time , end_time: day[i].end_time, day_of_week: day[0].day_of_week});
+                i++;
+            }
+            else {
+                mergedOverlapBusyTimes[day[0].day_of_week].push({start_time: day[i].start_time, end_time: day[i].end_time, day_of_week: day[0].day_of_week})
+            }
+        }
+    }
+
+    for (const day of mergedOverlapBusyTimes){
+        if(!day){
+            continue;
+        }
+        freeTimes[day[0].day_of_week] = [];
+        currentEndTime = STUDY_GROUPS_END;
+        day.map((busyTime) => {
+            if (busyTime.start_time < currentEndTime){
+                if ((busyTime.end_time < STUDY_GROUPS_START) && (STUDY_GROUPS_START !== currentEndTime)){
+                    freeTimes[day[0].day_of_week].push({start_time: STUDY_GROUPS_START, end_time: currentEndTime});
+                }
+                else {
+                    if (!(busyTime.end_time >= STUDY_GROUPS_END) && (busyTime.end_time !== currentEndTime)){
+                        freeTimes[day[0].day_of_week].push({start_time: busyTime.end_time, end_time: currentEndTime});
+                    }
+                }
+                currentEndTime = busyTime.start_time;
+            }
+        })
+        if ((currentEndTime > STUDY_GROUPS_START) && (STUDY_GROUPS_START !== currentEndTime)){
+            freeTimes[day[0].day_of_week].push({start_time: STUDY_GROUPS_START, end_time: currentEndTime});
+        }
+    }
+
+    for (let i = 1; i <= DAYS_IN_WEEK; i++){
+        if (!freeTimes[i]){
+            freeTimes[i] = [];
+            freeTimes[i].push({start_time: STUDY_GROUPS_START, end_time: STUDY_GROUPS_END});
+        }
+    }
+}
+
+const MatchByAvailability = (busyTimes) => {
+    const busyTimesPerDay = sortBusyTimes(busyTimes);
+    getFreeTimes(busyTimesPerDay);
+}
+
+export default MatchByAvailability;


### PR DESCRIPTION
## Description

- Creates a new array of the user's busy time slots that is organized by day of the week, contains the busy times in minutes, and merges overlapping events into one event.
- Utilizes this array to find all of the user's free time slots from 8 AM-8 PM and returns them in an array organized by day of the week.
- In the next PR, I will begin implementing my availability matching algorithm using these free time slots.

## Milestones
This works towards Milestone 6, which is that users can be matched into study groups based on availability.

## Resources

## Test Plan
<img width="1728" alt="Getting Free Times" src="https://github.com/user-attachments/assets/6c300e77-63f3-436a-b40a-d02161a48ce4" />

Besides testing basic functionality, these are the corner cases I tested:

- If a user has no busy times in a day, 8 AM - 8 PM on that day should be considered free.
- If a user has an all day event/class, there should be no free time slots for that day.
- Created events that start at exactly 8 AM and end exactly at 8 PM to ensure that there are no gaps in the free time slots.
- Created events before 8 AM and after 8 PM to ensure that they do not influence the free time slots, since these events are not between 8 AM - 8 PM.
- If there are overlapping events, the events should be merged into one event and there should be no gaps of free time between the overlap.
- If one event ends when another event begins, there is no free time between the two events.