### PR TITLE
Add Create New Group Functionality

### DIFF
--- a/client/src/components/CreateGroup.jsx
+++ b/client/src/components/CreateGroup.jsx
@@ -1,0 +1,13 @@
+import '../styles.css'
+
+const CreateGroup = ({setGroupModalIsOpen}) => {
+    const handleCreateGroup = () => {
+        setGroupModalIsOpen(true);
+    }
+
+    return (
+        <button className="buttons" id="create-group-button" onClick={handleCreateGroup}>Create a New Group</button>
+    )
+}
+
+export default CreateGroup;

--- a/client/src/components/NewGroupModal.jsx
+++ b/client/src/components/NewGroupModal.jsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import '../styles.css'
+import WeekDays from "../data/WeekDays";
+
+const NewGroupModal = ({groupModalIsOpen, onModalClose, createGroup, fetchData, classList}) => {
+    const TIME_INPUT_TYPE = "time";
+    const [className, setClassName] = useState("")
+    const [dayOfWeek, setDayOfWeek] = useState("")
+    const [startTime, setStartTime] = useState("08:00")
+    const [endTime, setEndTime] = useState("09:00")
+
+    if (!groupModalIsOpen){
+        return null;
+    }
+
+    const getClassId = async (className) => {
+        const classes = await fetchData('availability/classes/', "GET", {"Content-Type": "application/json"});
+        for (const c of classes){
+            if (c.name === className){
+                return c.id;
+            }
+        }
+    }
+
+    const handleNewGroupSubmit = async (event) => {
+        event.preventDefault();
+        const classId = await getClassId(className);
+        createGroup({class_id: classId, day_of_week: Number(dayOfWeek), start_time: startTime, end_time: endTime});
+        setClassName("");
+        setDayOfWeek("");
+        setStartTime("");
+        setEndTime("");
+        onModalClose();
+    }
+    
+    const handleModalClose = () => {
+        onModalClose();
+    }
+
+    const getEndTime = (startTime) => {
+        const [startHour, startMinute] = startTime.split(":").map(Number);
+        const endHour = (startHour + 1) % 24;
+        const formattedEndHour = endHour.toString().padStart(2, "0");
+        const formattedEndMinutes = startMinute.toString().padStart(2, "0");
+        const oneHourAfterStart = `${formattedEndHour}:${formattedEndMinutes}`;
+        setEndTime(oneHourAfterStart);
+    }
+
+    return (
+        <div className="new-group-modal">
+            <div className="new-group-modal-content">
+                <div className="new-group-modal-close-button">
+                    <span className="close" onClick={handleModalClose}>&times;</span>
+                </div>
+                <h3>Create a New Group</h3>
+                <form onSubmit={handleNewGroupSubmit} className="new-group-modal-form">
+                    <div className="new-group-modal-dropdowns">
+                    <select
+                        className="event-popup-inputs"
+                        value={className}
+                        onChange={(e) => {
+                            setClassName(e.target.value);
+                        }}
+                        required
+                    >
+                        <option value="" disabled>Select a Class</option>
+                        {classList.map((c) => (
+                            <option value={c.name} key={c.id}>{c.name}</option> 
+                        ))}
+                    </select>
+                    <select
+                        className="event-popup-inputs"
+                        value={dayOfWeek}
+                        onChange={(e) => {
+                            setDayOfWeek(e.target.value);
+                        }}
+                        required
+                    >
+                        <option value="" disabled>Day of the Week</option>
+                        {Object.keys(WeekDays).map((day) => (
+                            <option key={day} value={WeekDays[day]}>{day}</option>
+                        ))}
+                    </select>
+                    </div>
+                    <label>Start:</label>
+                    <div>
+                        <input
+                            className="event-popup-inputs"
+                            type={TIME_INPUT_TYPE}
+                            value={startTime}
+                            onChange={(event) => setStartTime(event.target.value)}
+                            onChangeCapture={(event) => getEndTime(event.target.value)}
+                            required
+                        />
+                    </div>
+                    <label>End:</label>
+                    <div>
+                        <input
+                            className="event-popup-inputs"
+                            type={TIME_INPUT_TYPE}
+                            value={endTime}
+                            readOnly
+                            required
+                        />
+                    </div>
+                    <div className="new-group-modal-buttons">
+                        <button type="submit" className="new-group-modal-submit">Submit</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+}
+
+export default NewGroupModal;

--- a/client/src/pages/GroupsPage.jsx
+++ b/client/src/pages/GroupsPage.jsx
@@ -1,19 +1,65 @@
 import { useNavigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
+import CreateGroup from '../components/CreateGroup';
+import NewGroupModal from '../components/NewGroupModal';
 
 const GroupsPage = () => {
+    const [groupModalIsOpen, setGroupModalIsOpen] = useState(false);
+    const [classList, setClassList] = useState([]);
+
+    const fetchData = async (endpoint, method = "GET", headers, credentials = "same-origin", body = null) => {
+        try {
+            const response = await fetch(`http://localhost:3000/${endpoint}`, {
+                method: method,
+                headers: headers,
+                credentials: credentials,
+                body: body,
+            });
+            if (!response.ok){
+                throw new Error('Not able to fetch data.')
+            }
+            const data = await response.json();
+            return data;
+        }
+        catch {
+            console.log("Error fetching data.")
+        }
+    }
+
+    const createGroup = async (newGroupData) => {
+        const newGroup = await fetchData("group/existingGroup/", "POST", {"Content-Type": "application/json"}, "same-origin", JSON.stringify(newGroupData));
+    }
+
+    const onModalClose = () => {
+        setGroupModalIsOpen(false);
+    }
+
+    useEffect(() => {
+        const fetchClasses = async () => {
+            const classData = await fetchData("availability/classes/", "GET");
+            const sortedClassData = classData.sort((a,b) => 
+                a.name.localeCompare(b.name)
+            )
+            setClassList(sortedClassData);
+        }
+        fetchClasses();
+    }, [])
+
     return (
-        <div className="profile-page">
-        <header className="profile-page-header">
-            <Navbar />
-            <h2>Your Groups</h2>
-        </header>
+        <div className="groups-page">
+            <header className="groups-page-header">
+                <Navbar />
+                <h2>Your Groups</h2>
+            </header>
 
-        <main className="profile-page-main">  
-        </main>
+            <main className="groups-page-main"> 
+                <CreateGroup setGroupModalIsOpen={setGroupModalIsOpen} /> 
+                <NewGroupModal groupModalIsOpen={groupModalIsOpen} onModalClose={onModalClose} createGroup={createGroup} fetchData={fetchData} classList={classList}/>
+            </main>
 
-        <Footer />
+            <Footer />
         </div>
     )
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -94,7 +94,7 @@ button:focus-visible {
     flex: 1;
 }
 
-.profile-page-main{
+.profile-page-main, .groups-page-main{
     display: flex;
     margin: 25px;
     flex: 1;
@@ -306,4 +306,92 @@ button:focus-visible {
 
 #submit-availability-button {
     margin-bottom: 100px;
+}
+
+#create-group-button {
+    width: 20%;
+}
+
+.new-group-modal {
+    display: flex; 
+    position: fixed; 
+    z-index: 1; 
+    left: 0;
+    top: 0;
+    width: 100%; 
+    height: 100%; 
+    overflow: auto; 
+    background-color: rgba(0,0,0,0.4); 
+    justify-content: center;
+    border-radius: 10px;
+}
+
+.new-group-modal-content {
+    background-color: #e8e9eb;
+    margin: 5% auto; 
+    padding: 40px;
+    border: 1px solid #888;
+    width: 50%;
+    height: 60%;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+    justify-content: center;
+    border-radius: 10px;
+}
+
+.new-group-modal-form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 20px;
+    margin-bottom: 30px;
+    justify-content: center;
+}
+
+.new-group-modal-dropdowns {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+}
+
+.new-group-modal-form input {
+    padding: 15px;
+}
+
+.modal-header {
+    display: flex;
+    flex-direction: column;
+}
+
+.new-group-modal-submit {
+    margin: 20px;
+    background-color: #068484;
+    color: white;
+}
+
+.new-group-modal-close-button {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+}
+
+.close {
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+}
+
+.close:hover,
+.close:focus {
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.modal-header {
+    display: flex;
+    align-items: flex-start;
+    flex-direction: column;
 }

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ const authRoutes = require('./routes/auth.js')
 const userRoutes = require('./routes/UserRoutes.js')
 const quizRoutes = require('./routes/QuizRoutes.js')
 const availabilityRoutes = require('./routes/AvailabilityRoutes.js')
+const groupRoutes = require('./routes/GroupRoutes.js')
 const session = require('express-session')
 
 app.use(cors({
@@ -26,6 +27,7 @@ app.use('/auth', authRoutes)
 app.use('/user', userRoutes)
 app.use('/quiz', quizRoutes)
 app.use('/availability', availabilityRoutes)
+app.use('/group', groupRoutes)
 
 app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`)

--- a/server/prisma/migrations/20250709051337_create_existing_groups_table/migration.sql
+++ b/server/prisma/migrations/20250709051337_create_existing_groups_table/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "existingGroups" (
+    "id" SERIAL NOT NULL,
+    "class_id" INTEGER NOT NULL,
+    "day_of_week" INTEGER NOT NULL,
+    "start_time" TEXT NOT NULL,
+    "end_time" TEXT NOT NULL,
+
+    CONSTRAINT "existingGroups_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_ExistingGroupToUser" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_ExistingGroupToUser_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_ExistingGroupToUser_B_index" ON "_ExistingGroupToUser"("B");
+
+-- AddForeignKey
+ALTER TABLE "_ExistingGroupToUser" ADD CONSTRAINT "_ExistingGroupToUser_A_fkey" FOREIGN KEY ("A") REFERENCES "existingGroups"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ExistingGroupToUser" ADD CONSTRAINT "_ExistingGroupToUser_B_fkey" FOREIGN KEY ("B") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/migrations/20250709052707_create_user_existing_groups_table/migration.sql
+++ b/server/prisma/migrations/20250709052707_create_user_existing_groups_table/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - You are about to drop the `_ExistingGroupToUser` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "_ExistingGroupToUser" DROP CONSTRAINT "_ExistingGroupToUser_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_ExistingGroupToUser" DROP CONSTRAINT "_ExistingGroupToUser_B_fkey";
+
+-- DropTable
+DROP TABLE "_ExistingGroupToUser";
+
+-- CreateTable
+CREATE TABLE "userExistingGroups" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "existing_group_id" INTEGER NOT NULL,
+
+    CONSTRAINT "userExistingGroups_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "userExistingGroups" ADD CONSTRAINT "userExistingGroups_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "userExistingGroups" ADD CONSTRAINT "userExistingGroups_existing_group_id_fkey" FOREIGN KEY ("existing_group_id") REFERENCES "existingGroups"("id") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   personality_quiz      Quiz?
   busy_times            BusyTime[] 
   user_classes          UserClass[]
+  groups                UserExistingGroup[]
 
   @@map("users")
 }
@@ -75,4 +76,25 @@ model UserClass {
   class            Class            @relation(fields: [class_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@map("userClasses")
+}
+
+model ExistingGroup {
+  id                    Int              @id @default(autoincrement())
+  class_id              Int
+  day_of_week           Int
+  start_time            String
+  end_time              String
+  user_existing_groups  UserExistingGroup[] 
+
+  @@map("existingGroups")
+}
+
+model UserExistingGroup {
+  id                  Int              @id @default(autoincrement())
+  user_id             Int
+  existing_group_id   Int
+  user                User             @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  existing_group      ExistingGroup    @relation(fields: [existing_group_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@map("userExistingGroups")
 }

--- a/server/routes/GroupRoutes.js
+++ b/server/routes/GroupRoutes.js
@@ -1,0 +1,32 @@
+const express = require('express')
+const { PrismaClient } = require('@prisma/client')
+const router = express.Router()
+const prisma = new PrismaClient();
+
+router.post('/existingGroup', async (req, res) => {
+    const {id, class_id, day_of_week, start_time, end_time} = req.body
+    const newExistingGroupData = await prisma.existingGroup.create({
+        data: {
+            id,
+            class_id,
+            day_of_week,
+            start_time,
+            end_time
+        }
+    })
+    res.json(newExistingGroupData);
+})
+
+router.post('/userExistingGroup', async (req, res) => {
+    const {id, user_id, existing_group_id} = req.body
+    const newUserExistingGroupData = await prisma.userExistingGroup.create({
+        data: {
+            id,
+            user_id,
+            existing_group_id
+        }
+    })
+    res.json(newUserExistingGroupData);
+})
+
+module.exports = router


### PR DESCRIPTION
## Description

- Creates ExistingGroup and UserExistingGroup database models, which will store the information for each group created by the user and all the users in each existing group.
- Creates POST routes to save an existing group and user existing group when a user submits the Create a New Group form.
- Implements a "Create a New Group" modal that allows the user to choose a class, day of week, and start time and saves this group to the database.
- Implements a function to calculate the new group end time by adding an hour to the start time so that users can only create study groups that meet for one hour.
- In the next PR, I will match users into existing study groups based on their availability.

## Milestones
This works towards Milestone 15, which is that the user can create a new group.

## Resources

## Test Plan

https://github.com/user-attachments/assets/4bf58d8a-08be-42c4-b43a-b3e05ea2cf24


Besides testing basic functionality, these are the corner cases I've tested:

- Set several different start times, including times in the morning, afternoon, and at irregular hours to ensure that the end time is always exactly one hour after the start time.
- Set time as 0 to ensure that it defaults to 12:00 AM and the end time becomes 01:00 AM.
- Attempted to edit the end time to ensure that it is read-only and can only be changed when the start time is changed.
