### PR TITLE
Find Users for Existing Groups Based on Availability

### DIFF
--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -134,7 +134,7 @@ const Calendar = () => {
 
     const matchByAvailability = () => {
         if (busyTimes){
-            MatchByAvailability(busyTimes, fetchData);
+            MatchByAvailability(fetchData);
         }
     }
 

--- a/client/src/components/NewGroupModal.jsx
+++ b/client/src/components/NewGroupModal.jsx
@@ -28,8 +28,8 @@ const NewGroupModal = ({groupModalIsOpen, onModalClose, createGroup, fetchData, 
         createGroup({class_id: classId, day_of_week: Number(dayOfWeek), start_time: startTime, end_time: endTime});
         setClassName("");
         setDayOfWeek("");
-        setStartTime("");
-        setEndTime("");
+        setStartTime("08:00");
+        setEndTime("09:00");
         onModalClose();
     }
     

--- a/client/src/pages/GroupsPage.jsx
+++ b/client/src/pages/GroupsPage.jsx
@@ -4,10 +4,12 @@ import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
 import CreateGroup from '../components/CreateGroup';
 import NewGroupModal from '../components/NewGroupModal';
+import { useUser } from "../contexts/UserContext";
 
 const GroupsPage = () => {
     const [groupModalIsOpen, setGroupModalIsOpen] = useState(false);
     const [classList, setClassList] = useState([]);
+    const {user, setUser} = useUser();
 
     const fetchData = async (endpoint, method = "GET", headers, credentials = "same-origin", body = null) => {
         try {
@@ -28,8 +30,17 @@ const GroupsPage = () => {
         }
     }
 
+    const addUserToGroup = async (newGroupId) => {
+        const newUserExistingGroupData = {
+            user_id: user.id,
+            existing_group_id: newGroupId
+        }
+        const newUserExistingGroup = await fetchData("group/userExistingGroup/", "POST", {"Content-Type": "application/json"}, "same-origin", JSON.stringify(newUserExistingGroupData));
+    }
+
     const createGroup = async (newGroupData) => {
         const newGroup = await fetchData("group/existingGroup/", "POST", {"Content-Type": "application/json"}, "same-origin", JSON.stringify(newGroupData));
+        addUserToGroup(newGroup.id);
     }
 
     const onModalClose = () => {

--- a/server/routes/GroupRoutes.js
+++ b/server/routes/GroupRoutes.js
@@ -29,4 +29,14 @@ router.post('/userExistingGroup', async (req, res) => {
     res.json(newUserExistingGroupData);
 })
 
+router.get('/existingGroup', async (req, res) => {
+    const existingGroups = await prisma.existingGroup.findMany();
+    res.json(existingGroups);
+})
+
+router.get('/userExistingGroup', async (req, res) => {
+    const userExistingGroups = await prisma.userExistingGroup.findMany();
+    res.json(userExistingGroups);
+})
+
 module.exports = router


### PR DESCRIPTION
## Description

- Adds a user to an existing group when the user creates the group using the "Create a New Group" form.
- Creates GET routes to fetch all existing groups.
- Loops through all existing groups and creates an array where each element contains the class_id of the existing group, day of the week, start time, end time, and all the users that are available during that time and are taking that class.
- In the next PR, I will display the possible groups for each user on the Groups Page.

## Milestones
This works towards Milestone 6, which is that users can be matched into study groups based on availability (technical challenge 2).

## Resources

## Test Plan
<img width="1728" alt="Find Groups by Availability" src="https://github.com/user-attachments/assets/e7a0e847-af72-4f8e-932b-579791879544" />

Besides testing basic functionality, these are the corner cases I've tested:

- Created groups with classes that aren't taken by any users to ensure that no users are matched into that group, even though they have the availability.
- Created a new group for a class that all users were taking but at a time when no users had availability to ensure that "users" would only have one user_id for this group, the id of the user who created the group.
- Created a new group for a class that all users were taking at a time when all users were available to ensure that "users" would contain the ids of all the users taking this class.
- Edited a user's availability to conflict with an existing group to make sure that the algorithm updates this existing group to no longer contain the user.