### PR TITLE
Display Groups Created by the User

### DIFF
--- a/client/src/components/GroupCard.jsx
+++ b/client/src/components/GroupCard.jsx
@@ -1,0 +1,18 @@
+import '../styles.css'
+
+const GroupCard = ({className, dayOfWeek, time, users}) => {
+    return (
+        <div className="group-card">
+            <h3 className="group-card-title">{className}</h3>
+            <p className="group-card-day">{dayOfWeek}</p>
+            <p className="group-card-time">{time}</p>
+            <p className="group-card-users">Members: {users}</p>
+            <div className="group-card-buttons">
+                <button className="buttons">Accept</button>
+                <button className="buttons">Reject</button>
+            </div>
+        </div>
+    )
+}
+
+export default GroupCard;

--- a/client/src/components/GroupList.jsx
+++ b/client/src/components/GroupList.jsx
@@ -1,0 +1,50 @@
+import GroupCard from './GroupCard'
+import '../styles.css'
+import WeekDays from '../data/WeekDays'
+import { useEffect, useState } from 'react'
+
+const GroupList = ({data, user, existingGroups, getClassName, getUserName}) => {
+    const GENERIC_DATE = `2025-07-01T`;
+    const [userExistingGroups, setUserExistingGroups] = useState([]);
+
+    const getExistingGroupInfo = (groupId) => {
+        for (const group of existingGroups){
+            const startTime = new Date(`${GENERIC_DATE}${group.start_time}`);
+            const formattedStart = startTime.toLocaleTimeString('en-US', {hour: 'numeric', minute:'2-digit', hour12: true});
+            const endTime = new Date(`${GENERIC_DATE}${group.end_time}`);
+            const formattedEnd = endTime.toLocaleTimeString('en-US', {hour: 'numeric', minute:'2-digit', hour12: true});
+            if (group.id == groupId){
+                return {class_id: group.class_id, day_of_week: group.day_of_week, start_time: formattedStart, end_time: formattedEnd}
+            }
+        }
+    }
+
+    useEffect(() => {
+        setUserExistingGroups(data);
+    }, [data])
+
+    return (
+        <main>
+            <div className="group-list-container">
+                {
+                    userExistingGroups.map(obj => {
+                        if (user) {
+                            if (obj.user_id == user.id){
+                                const groupInfo = getExistingGroupInfo(obj.existing_group_id);
+                                const className = getClassName(groupInfo.class_id);
+                                const dayOfWeek = Object.keys(WeekDays)[groupInfo.day_of_week - 1];
+                                const time = groupInfo.start_time + " - " + groupInfo.end_time;
+                                const userNames = getUserName(obj.user_id);
+                                return (
+                                    <GroupCard key={obj.id} className={className} dayOfWeek={dayOfWeek} time={time} users={userNames}/>
+                                )
+                            }
+                        }
+                    })
+                }
+            </div>
+        </main>
+    )
+}
+
+export default GroupList;

--- a/client/src/components/NewGroupModal.jsx
+++ b/client/src/components/NewGroupModal.jsx
@@ -2,12 +2,15 @@ import { useState } from "react";
 import '../styles.css'
 import WeekDays from "../data/WeekDays";
 
-const NewGroupModal = ({groupModalIsOpen, onModalClose, createGroup, fetchData, classList}) => {
+const NewGroupModal = ({groupModalIsOpen, onModalClose, createGroup, fetchData, classList, fetchExistingGroups}) => {
     const TIME_INPUT_TYPE = "time";
+    const DEFAULT_START = "08:00";
+    const DEFAULT_END = "09:00";
+    const HOURS_IN_DAY = 24;
     const [className, setClassName] = useState("")
     const [dayOfWeek, setDayOfWeek] = useState("")
-    const [startTime, setStartTime] = useState("08:00")
-    const [endTime, setEndTime] = useState("09:00")
+    const [startTime, setStartTime] = useState(DEFAULT_START)
+    const [endTime, setEndTime] = useState(DEFAULT_END)
 
     if (!groupModalIsOpen){
         return null;
@@ -28,8 +31,9 @@ const NewGroupModal = ({groupModalIsOpen, onModalClose, createGroup, fetchData, 
         createGroup({class_id: classId, day_of_week: Number(dayOfWeek), start_time: startTime, end_time: endTime});
         setClassName("");
         setDayOfWeek("");
-        setStartTime("08:00");
-        setEndTime("09:00");
+        setStartTime(DEFAULT_START);
+        setEndTime(DEFAULT_END);
+        fetchExistingGroups();
         onModalClose();
     }
     
@@ -39,7 +43,7 @@ const NewGroupModal = ({groupModalIsOpen, onModalClose, createGroup, fetchData, 
 
     const getEndTime = (startTime) => {
         const [startHour, startMinute] = startTime.split(":").map(Number);
-        const endHour = (startHour + 1) % 24;
+        const endHour = (startHour + 1) % HOURS_IN_DAY;
         const formattedEndHour = endHour.toString().padStart(2, "0");
         const formattedEndMinutes = startMinute.toString().padStart(2, "0");
         const oneHourAfterStart = `${formattedEndHour}:${formattedEndMinutes}`;

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -86,11 +86,16 @@ button:focus-visible {
     flex-direction: column;
 }
 
-.home-main, .groups-page-main{
+.home-main {
     display: flex;
     justify-content: center;
     align-items: center;
-    margin: 25px;
+}
+
+.groups-page-main {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     flex: 1;
 }
 
@@ -309,7 +314,7 @@ button:focus-visible {
 }
 
 #create-group-button {
-    width: 20%;
+    margin-bottom: 40px;
 }
 
 .new-group-modal {
@@ -394,4 +399,46 @@ button:focus-visible {
     display: flex;
     align-items: flex-start;
     flex-direction: column;
+}
+
+.group-list-container {
+    gap: 15px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding-bottom: 80px;
+}
+
+.group-card {
+    text-align: center;
+    padding: 15px;
+    width: 200px;
+    margin: 20px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    border: 1px solid black;
+    box-shadow: 0 12px 20px rgba(0,0,0,0.15);
+    border-radius: 10px;
+    padding-bottom: 30px;
+}
+
+.group-card-buttons {
+    display: flex;
+    justify-content: center;
+    font-size: 12px;
+    gap: 10px;
+}
+
+.group-card:hover {
+    transform: scale(1.03) translateY(-2px);
+}
+
+.group-card-title {
+    border-bottom: 1px solid black;
+    padding-bottom: 5px;
+}
+
+.group-card-buttons {
+    gap: 20px;
 }

--- a/server/routes/UserRoutes.js
+++ b/server/routes/UserRoutes.js
@@ -28,4 +28,9 @@ router.get('/profilePicture/:userId', async (req, res) => {
     res.send(currentUser.profile_picture)
 })
 
+router.get('/', async (req, res) => {
+    const users = await prisma.user.findMany();
+    res.json(users);
+})
+
 module.exports = router


### PR DESCRIPTION
## Description

- Creates GroupCard component to display the class, day, time, and members of each study group.
- Creates GroupList component to display all the GroupCards in a grid view on the Groups Page.
- Implements styling for the GroupCard and GroupList components to display study group information in a user-friendly manner.
- In the next PR, I will display all the existing study groups suggested for the user by my availability scheduling algorithm.

## Milestones
This works towards Milestone 15, which is that the user can create a new group, and Milestone 6, which is that the user can be matched into study groups based on availability (technical challenge).

## Resources

## Test Plan

https://github.com/user-attachments/assets/926141a1-4ce2-4a4b-91a8-9aa71eaa9dab

Besides testing basic functionality, these are the corner cases I tested:

- Logged into several different accounts to ensure that only the groups containing the specific user were visible on that user's Groups Page.
- Refreshed the page and navigated to and from the Groups Page to ensure that the groups are always displayed.
- Created groups during several different times, including in the afternoon, and on several different days, to ensure that the time is properly converted from military time and the day of the week is properly converted from its integer value.