### PR TITLE
Match Users into Groups Based on Preferred Times

### DIFF
--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -7,6 +7,7 @@ import EventPopup from "./EventPopup";
 import { useUser } from "../contexts/UserContext";
 import WeekDays from "../data/WeekDays";
 import MatchByAvailability from "../utils/MatchByAvailability";
+import { useNavigate } from "react-router-dom";
 
 const localizer = momentLocalizer(moment);
 const DEFAULT_YEAR = 2025;
@@ -21,6 +22,8 @@ const Calendar = () => {
     const [selectedEvent, setSelectedEvent] = useState(null);
     const [eventId, setEventId] = useState();
     const [busyTimes, setBusyTimes] = useState([]);
+    const [allUsers, setAllUsers] = useState([]);
+    const navigate = useNavigate();
 
     const eventPropGetter = (event) => {
         const backgroundColor = '#068484';
@@ -128,13 +131,20 @@ const Calendar = () => {
             localizer.format(date, 'dddd', culture),
     }
 
+    const fetchUsers = async () => {
+        const users = await fetchData("user/", "GET");
+        setAllUsers(users);
+    }
+
     useEffect(() => {
         fetchEvents();
+        fetchUsers();
     }, [user])
 
     const matchByAvailability = () => {
         if (busyTimes){
-            MatchByAvailability(fetchData);
+            MatchByAvailability(fetchData, allUsers);
+            navigate("/groups");
         }
     }
 

--- a/client/src/components/GroupCard.jsx
+++ b/client/src/components/GroupCard.jsx
@@ -6,7 +6,14 @@ const GroupCard = ({className, dayOfWeek, time, users}) => {
             <h3 className="group-card-title">{className}</h3>
             <p className="group-card-day">{dayOfWeek}</p>
             <p className="group-card-time">{time}</p>
-            <p className="group-card-users">Members: {users}</p>
+            <h5 className="group-card-users">Members:</h5>
+            <div className="group-card-members">
+                {users.map((item, index) => {
+                    return (
+                        <p className="group-card-member" key={index}>{item}</p>
+                    )
+                })}
+            </div>
             <div className="group-card-buttons">
                 <button className="buttons">Accept</button>
                 <button className="buttons">Reject</button>

--- a/client/src/components/GroupList.jsx
+++ b/client/src/components/GroupList.jsx
@@ -19,6 +19,16 @@ const GroupList = ({data, user, existingGroups, getClassName, getUserName}) => {
         }
     }
 
+    const getGroupMembers = (groupId) => {
+        const groupMembers = [];
+        for (const group of userExistingGroups){
+            if (group.existing_group_id === groupId){
+                groupMembers.push(group.user_id)
+            }
+        }
+        return groupMembers;
+    }
+
     useEffect(() => {
         setUserExistingGroups(data);
     }, [data])
@@ -34,7 +44,11 @@ const GroupList = ({data, user, existingGroups, getClassName, getUserName}) => {
                                 const className = getClassName(groupInfo.class_id);
                                 const dayOfWeek = Object.keys(WeekDays)[groupInfo.day_of_week - 1];
                                 const time = groupInfo.start_time + " - " + groupInfo.end_time;
-                                const userNames = getUserName(obj.user_id);
+                                const groupMembers = getGroupMembers(obj.existing_group_id)
+                                let userNames = []
+                                for (const member of groupMembers){
+                                    userNames.push(getUserName(member))
+                                }
                                 return (
                                     <GroupCard key={obj.id} className={className} dayOfWeek={dayOfWeek} time={time} users={userNames}/>
                                 )

--- a/client/src/components/SignupForm.jsx
+++ b/client/src/components/SignupForm.jsx
@@ -69,33 +69,56 @@ const SignupForm = () => {
             </div>
             <h2>Sign Up</h2>
             <form className="signup-form" onSubmit={handleSubmit}>
-                <label htmlFor="name">Name</label>
-                <input
-                    type="text"
-                    className="signup-inputs"
-                    id="name"
-                    name="name"
-                    value={formData.name}
-                    onChange={handleChange}
-                />
-                <label htmlFor="username">Username</label>
-                <input
-                    type="text"
-                    className="signup-inputs"
-                    id="username"
-                    name="username"
-                    value={formData.username}
-                    onChange={handleChange}
-                />
-                <label htmlFor="password">Password</label>
-                <input
-                    type="password"
-                    className="signup-inputs"
-                    id="password"
-                    name="password"
-                    value={formData.password}
-                    onChange={handleChange}
-                />
+                <div className="signup-form-top-section">
+                    <label htmlFor="name">Full Name</label>
+                    <input
+                        type="text"
+                        className="signup-inputs"
+                        id="name"
+                        name="name"
+                        value={formData.name}
+                        onChange={handleChange}
+                    />
+                    <label htmlFor="username">Username</label>
+                    <input
+                        type="text"
+                        className="signup-inputs"
+                        id="username"
+                        name="username"
+                        value={formData.username}
+                        onChange={handleChange}
+                    />
+                    <label htmlFor="password">Password</label>
+                    <input
+                        type="password"
+                        className="signup-inputs"
+                        id="password"
+                        name="password"
+                        value={formData.password}
+                        onChange={handleChange}
+                    />
+                </div>
+                <div className="signup-form-second-section"><h4>Study Group Preferences</h4>
+                    <label htmlFor="preferred-time">Preferred Meeting Hours</label>
+                    <div className="signup-time-inputs">
+                        <input
+                            type="time"
+                            className="signup-inputs"
+                            id="preferred-start-time"
+                            name="preferred_start_time"
+                            value={formData.preferred_start_time}
+                            onChange={handleChange}
+                        />
+                        <input
+                            type="time"
+                            className="signup-inputs"
+                            id="preferred-end-time"
+                            name="preferred_end_time"
+                            value={formData.preferred_end_time}
+                            onChange={handleChange}
+                        />
+                    </div>
+                </div>
                 <div className="form-buttons">
                     <button className="buttons" type="submit">Sign Up</button>
                 </div>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -193,6 +193,23 @@ button:focus-visible {
     border-radius: 5px;
 }
 
+.signup-form-top-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.signup-form-second-section {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.signup-time-inputs {
+    display: flex;
+    gap: 10px;
+}
+
 .footer {
     display: flex;
     background-color: #068484;
@@ -442,3 +459,15 @@ button:focus-visible {
 .group-card-buttons {
     gap: 20px;
 }
+
+.group-card-users {
+    display: flex;
+    justify-content: center;
+    margin-bottom: auto;
+}
+
+.group-card-members {
+    margin-bottom: 20px;
+}
+
+

--- a/server/prisma/migrations/20250711172401_update_user_table/migration.sql
+++ b/server/prisma/migrations/20250711172401_update_user_table/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "preferred_end_time" TEXT,
+ADD COLUMN     "preferred_start_time" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -20,6 +20,8 @@ model User {
   password              String
   profile_picture       Bytes?         
   created_at            DateTime       @default(now())
+  preferred_start_time  String?
+  preferred_end_time    String?
   personality_quiz      Quiz?
   busy_times            BusyTime[] 
   user_classes          UserClass[]

--- a/server/routes/UserRoutes.js
+++ b/server/routes/UserRoutes.js
@@ -33,4 +33,12 @@ router.get('/', async (req, res) => {
     res.json(users);
 })
 
+router.get('/preferredTimes/:userId', async (req, res) => {
+    const userId = parseInt(req.params.userId)
+    const currentUser = await prisma.user.findUnique({
+        where: {id: parseInt(userId)},
+    });
+    res.json({preferred_start_time: currentUser.preferred_start_time, preferred_end_time: currentUser.preferred_end_time});
+})
+
 module.exports = router

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -6,10 +6,10 @@ const prisma = new PrismaClient();
 
 // Create an account
 router.post('/signup', async (req, res) => {
-    const {name, username, password} = req.body
+    const {name, username, password, preferred_start_time, preferred_end_time} = req.body
     try {
-        if (!username || !password || !name) {
-            return res.status(400).json({error: "Username, password, and name are required."})
+        if (!username || !password || !name || !preferred_start_time || !preferred_end_time) {
+            return res.status(400).json({error: "Username, password, name, and preferences are required."})
         }
         
         if (password.length < 8) {
@@ -32,7 +32,9 @@ router.post('/signup', async (req, res) => {
             data: {
                 name,
                 username,
-                password: hashedPassword
+                password: hashedPassword,
+                preferred_start_time,
+                preferred_end_time,
             }
         })
 


### PR DESCRIPTION
## Description

- Creates input fields for preferred start time and end time in the signup form and saves these values to the database.
- Filters through all the existing study groups that a user is matched into based on availability and finds the groups that fall within the user's preferred study time range.
- Displays all the groups during which a user is available, taking that specific class, and that fall into the user's preferred study time range on the Groups Page.
- Updates GroupCard to display all the users in a group under "Members".

## Milestones
This works towards Milestone 6, which is that the user can be matched into study groups based on availability (technical challenge).

## Resources

## Test Plan
<img width="1728" height="957" alt="New Signup Form" src="https://github.com/user-attachments/assets/00912d1f-a099-4161-87a2-09d0590768ea" />

https://github.com/user-attachments/assets/a5791877-a25b-4e7a-a96f-439bff833fee

Besides testing basic functionality, these are the corner cases I tested:

- Attempted to create an account without inputting preferred start and end times to ensure that an error message appears.
- Created several groups during which a user is available but that don't fall into that user's preferred time range to ensure that they don't appear on the Groups Page.
- Created an account where a user is only available during one of the existing groups to ensure that this group is displayed, even if it doesn't fall into the user's preferred times.
- Logged into the accounts of each individual user in a group to ensure that the same group appears on each user's Groups Page.
- Ensured that even if an existing group falls within a user's preferred time range, it will not appear on the Groups Page if the user is not taking that specific class.