### PR TITLE
Calculate group compatibility score

### DIFF
--- a/client/src/components/GroupCard.jsx
+++ b/client/src/components/GroupCard.jsx
@@ -1,7 +1,7 @@
 import '../styles.css'
 
 // Contains the information for an individual study group
-const GroupCard = ({className, dayOfWeek, time, users}) => {
+const GroupCard = ({className, dayOfWeek, time, users, groupCompatibilityScore}) => {
     return (
         <div className="group-card">
             <h3 className="group-card-title">{className}</h3>
@@ -15,6 +15,7 @@ const GroupCard = ({className, dayOfWeek, time, users}) => {
                     )
                 })}
             </div>
+            <p className="group-compatibility">Group Compatibility Score: {groupCompatibilityScore}</p>
             <div className="group-card-buttons">
                 <button className="buttons">Accept</button>
                 <button className="buttons">Reject</button>

--- a/client/src/components/GroupList.jsx
+++ b/client/src/components/GroupList.jsx
@@ -56,7 +56,7 @@ const GroupList = ({data, user, existingGroups, getClassName, getUserName, fetch
                 }
             }
             const finalScores = await Promise.all(compatibilityScorePromises);
-            compatibilityScores[groupId] = calculateGroupCompatibilityScore(finalScores);
+            compatibilityScores[groupId] = calculateGroupCompatibilityScore(finalScores).toFixed(2);
         }
         setGroupScores(compatibilityScores);
     }

--- a/client/src/data/ScoreWeights.js
+++ b/client/src/data/ScoreWeights.js
@@ -1,0 +1,10 @@
+// Weights for each individual metric used to calculate the overall compatibility score
+const ScoreWeights = {
+    personality: 0.2,
+    location: 0.4,
+    goals: 0.2,
+    school: 0.1,
+    class_standing: 0.1,
+}
+
+export default ScoreWeights;

--- a/client/src/pages/GroupsPage.jsx
+++ b/client/src/pages/GroupsPage.jsx
@@ -116,7 +116,7 @@ const GroupsPage = () => {
                 {isLoading ? (
                     <div>Loading...</div>
                 ) : (
-                    <GroupList data={userExistingGroups} user={user} existingGroups={existingGroups} getClassName={getClassName} getUserName={getUserName}/>
+                    <GroupList data={userExistingGroups} user={user} existingGroups={existingGroups} getClassName={getClassName} getUserName={getUserName} fetchData={fetchData}/>
                 )}
                 {error && (
                     <p>{error}</p>


### PR DESCRIPTION
## Description

- Calculates the overall compatibility score between two users using the personality, location, school, class standing, and study goals metrics and their respective weights.
- Calculates the group compatibility score for each study group by finding the average of all of the user's compatibility scores with every other user in the group.
- Displays the compatibility score for each group on the Group Cards.
- In the next PR, I will rank the Group Cards by compatibility and clearly recommend a group for each class to the user.

## Milestones
This works towards Milestone 7, which is that the user can be matched into study groups based on a compatibility score (technical challenge 1).

## Resources

## Test Plan
<img width="1728" height="949" alt="Screenshot 2025-07-16 at 10 28 10 AM" src="https://github.com/user-attachments/assets/551fa807-8c8e-4c83-b7b3-a1bf7c430b91" />

Besides testing basic functionality, these are the corner cases I tested:

- Created a new group to ensure that the group compatibility score would be set to 1 since there is originally only one user in the group.
- Created users that are perfectly compatible to ensure that the group compatibility score would remain 1.
- Created users with big differences in location, which has the highest weight, and compared their compatibility scores to those of users who have big differences in class standing, which has the lowest weight. After doing this, the compatibility score of the users with location differences was much lower than the scores of those with class standing differences because location has a much higher weight in my algorithm.
- Calculated group scores that result in large floats to ensure that all scores are rounded to two decimal places before being displayed.