### PR TITLE
Calculate Compatibility Score with Missing Metrics

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,11 +12,13 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.2.0",
         "@mui/material": "^7.2.0",
+        "bootstrap": "^5.3.7",
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
         "moment": "^2.30.1",
         "react": "^19.1.0",
         "react-big-calendar": "^1.19.4",
+        "react-bootstrap": "^2.10.10",
         "react-colorful": "^5.6.1",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2"
@@ -1429,6 +1431,21 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.9.tgz",
+      "integrity": "sha512-2P5thfjfPy/np18e5wD4WPt8ydNXhij1jwA8oehxZTFqlgVMGXzcWKxTb4RtJrLFsqPO7RUQTiY8QJk0M4Vy2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@restart/hooks": {
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
@@ -1439,6 +1456,48 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@restart/ui": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
+      "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@popperjs/core": "^2.11.8",
+        "@react-aria/ssr": "^3.5.0",
+        "@restart/hooks": "^0.5.0",
+        "@types/warning": "^3.0.3",
+        "dequal": "^2.0.3",
+        "dom-helpers": "^5.2.0",
+        "uncontrollable": "^8.0.4",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/@restart/hooks": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
+      "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/uncontrollable": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
+      "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.14.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1728,6 +1787,15 @@
         "win32"
       ]
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1939,6 +2007,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bootstrap": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
+      "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2029,6 +2116,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -3193,6 +3286,25 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/prop-types-extra": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
+      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^16.3.2",
+        "warning": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
+      }
+    },
+    "node_modules/prop-types-extra/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -3253,6 +3365,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/react-bootstrap": {
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.10.tgz",
+      "integrity": "sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7",
+        "@restart/hooks": "^0.4.9",
+        "@restart/ui": "^1.9.4",
+        "@types/prop-types": "^15.7.12",
+        "@types/react-transition-group": "^4.4.6",
+        "classnames": "^2.3.2",
+        "dom-helpers": "^5.2.1",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.8.1",
+        "prop-types-extra": "^1.1.0",
+        "react-transition-group": "^4.4.5",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.8",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-colorful": {
@@ -3566,6 +3709,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/client/package.json
+++ b/client/package.json
@@ -14,11 +14,13 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.2.0",
     "@mui/material": "^7.2.0",
+    "bootstrap": "^5.3.7",
     "cors": "^2.8.5",
     "date-fns": "^4.1.0",
     "moment": "^2.30.1",
     "react": "^19.1.0",
     "react-big-calendar": "^1.19.4",
+    "react-bootstrap": "^2.10.10",
     "react-colorful": "^5.6.1",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2"

--- a/client/src/data/ScoreWeights.js
+++ b/client/src/data/ScoreWeights.js
@@ -1,10 +1,10 @@
 // Weights for each individual metric used to calculate the overall compatibility score
 const ScoreWeights = {
-    personality: 0.2,
-    location: 0.4,
-    goals: 0.2,
-    school: 0.1,
-    class_standing: 0.1,
+    personalityScore: 0.2,
+    locationScore: 0.4,
+    goalsScore: 0.2,
+    schoolScore: 0.1,
+    classStandingScore: 0.1,
 }
 
 export default ScoreWeights;

--- a/client/src/utils/CompatibilityScore.jsx
+++ b/client/src/utils/CompatibilityScore.jsx
@@ -37,41 +37,61 @@ const calculatePairPersonalityScore = async (firstUserId, secondUserId, fetchDat
 const calculateLocationDistance = async (firstUserId, secondUserId, fetchData) => {
     const firstUserCoordinates = await fetchData(`user/address/${firstUserId}`, "GET");
     const secondUserCoordinates = await fetchData(`user/address/${secondUserId}`, "GET");
-    const PI_VALUE = Math.PI;
-    const DEGREES_IN_PI_RADIANS = 180;
-    const RADIUS_OF_EARTH_IN_MILES = 3959;
-    const latitudeDistance = (secondUserCoordinates.latitude - firstUserCoordinates.latitude) * PI_VALUE / DEGREES_IN_PI_RADIANS;
-    const longitudeDistance = (secondUserCoordinates.longitude - firstUserCoordinates.longitude) * PI_VALUE / DEGREES_IN_PI_RADIANS;
-    const firstLatitudeInRadians = firstUserCoordinates.latitude * PI_VALUE / DEGREES_IN_PI_RADIANS;
-    const secondLatitudeInRadians = secondUserCoordinates.latitude * PI_VALUE / DEGREES_IN_PI_RADIANS;
-    const a = Math.pow(Math.sin(latitudeDistance / 2), 2) + Math.pow(Math.sin(longitudeDistance / 2), 2) * Math.cos(firstLatitudeInRadians) * Math.cos(secondLatitudeInRadians);
-    const centralAngle = 2 * Math.asin(Math.sqrt(a));
-    return centralAngle * RADIUS_OF_EARTH_IN_MILES;
+    if (firstUserCoordinates.latitude && firstUserCoordinates.longitude && secondUserCoordinates.latitude && secondUserCoordinates.longitude){
+        const PI_VALUE = Math.PI;
+        const DEGREES_IN_PI_RADIANS = 180;
+        const RADIUS_OF_EARTH_IN_MILES = 3959;
+        const latitudeDistance = (secondUserCoordinates.latitude - firstUserCoordinates.latitude) * PI_VALUE / DEGREES_IN_PI_RADIANS;
+        const longitudeDistance = (secondUserCoordinates.longitude - firstUserCoordinates.longitude) * PI_VALUE / DEGREES_IN_PI_RADIANS;
+        const firstLatitudeInRadians = firstUserCoordinates.latitude * PI_VALUE / DEGREES_IN_PI_RADIANS;
+        const secondLatitudeInRadians = secondUserCoordinates.latitude * PI_VALUE / DEGREES_IN_PI_RADIANS;
+        const a = Math.pow(Math.sin(latitudeDistance / 2), 2) + Math.pow(Math.sin(longitudeDistance / 2), 2) * Math.cos(firstLatitudeInRadians) * Math.cos(secondLatitudeInRadians);
+        const centralAngle = 2 * Math.asin(Math.sqrt(a));
+        return centralAngle * RADIUS_OF_EARTH_IN_MILES;
+    }
+    else {
+        return null;
+    }
 }
 
 // Calculates location compatibility score between two users using the distance between their addresses and the max reasonable distance a user can travel (75 miles)
 const calculateLocationScore = async (firstUserId, secondUserId, fetchData) => {
     const distanceBetweenLocations = await calculateLocationDistance(firstUserId, secondUserId, fetchData);
-    const MAX_DISTANCE_IN_MILES = 75;
-    return 1 - (distanceBetweenLocations / MAX_DISTANCE_IN_MILES);
+    if (distanceBetweenLocations){
+        const MAX_DISTANCE_IN_MILES = 75;
+        return 1 - (distanceBetweenLocations / MAX_DISTANCE_IN_MILES);
+    }
+    else {
+        return null;
+    }
 }
 
 // Uses mean absolute deviation of two class standings to calculate class standing compatibility score
 const calculateClassStandingScore = (firstSchoolInfo, secondSchoolInfo) => {
-    const NUM_OF_CLASS_STANDINGS = 4;
-    const standingDifference = Math.abs(SchoolStanding[secondSchoolInfo.class_standing] - SchoolStanding[firstSchoolInfo.class_standing]);
-    return 1 - (standingDifference / NUM_OF_CLASS_STANDINGS);
+    if (firstSchoolInfo.class_standing && firstSchoolInfo.school && secondSchoolInfo.class_standing && secondSchoolInfo.school){
+        const NUM_OF_CLASS_STANDINGS = 4;
+        const standingDifference = Math.abs(SchoolStanding[secondSchoolInfo.class_standing] - SchoolStanding[firstSchoolInfo.class_standing]);
+        return 1 - (standingDifference / NUM_OF_CLASS_STANDINGS);
+    }
+    else {
+        return null;
+    }
 }
 
 // Returns 1 if users attend the same school and 0 otherwise
 const calculateSchoolScore = (firstSchoolInfo, secondSchoolInfo) => {
-    const firstUserSchool = firstSchoolInfo.school.toLowerCase().replace(/\s/g, '');
-    const secondUserSchool = secondSchoolInfo.school.toLowerCase().replace(/\s/g, '');
-    if (firstUserSchool === secondUserSchool){
-        return 1;
+    if (firstSchoolInfo.class_standing && firstSchoolInfo.school && secondSchoolInfo.class_standing && secondSchoolInfo.school){
+        const firstUserSchool = firstSchoolInfo.school.toLowerCase().replace(/\s/g, '');
+        const secondUserSchool = secondSchoolInfo.school.toLowerCase().replace(/\s/g, '');
+        if (firstUserSchool === secondUserSchool){
+            return 1;
+        }
+        else {
+            return 0;
+        }
     }
     else {
-        return 0;
+        return null;
     }
 }
 
@@ -79,37 +99,53 @@ const calculateSchoolScore = (firstSchoolInfo, secondSchoolInfo) => {
 const calculateGoalsScore = async (firstUserId, secondUserId, fetchData) => {
     const firstUserGoals = await fetchData(`user/userGoals/${firstUserId}`, "GET");
     const secondUserGoals = await fetchData(`user/userGoals/${secondUserId}`, "GET");
-    const firstUserGoalIds = [];
-    for (const goal of firstUserGoals){
-        firstUserGoalIds.push(goal.goal_id)
+    if (firstUserGoals && secondUserGoals){
+        const firstUserGoalIds = [];
+        for (const goal of firstUserGoals){
+            firstUserGoalIds.push(goal.goal_id)
+        }
+        const secondUserGoalIds = [];
+        for (const goal of secondUserGoals){
+            secondUserGoalIds.push(goal.goal_id)
+        }
+        const firstUserSet = new Set(firstUserGoalIds);
+        const secondUserSet = new Set(secondUserGoalIds);
+        const unionSet = firstUserSet.union(secondUserSet);
+        const intersectionSet = firstUserSet.intersection(secondUserSet);
+        return intersectionSet.size / unionSet.size;
     }
-    const secondUserGoalIds = [];
-    for (const goal of secondUserGoals){
-        secondUserGoalIds.push(goal.goal_id)
+    else {
+        return null;
     }
-    const firstUserSet = new Set(firstUserGoalIds);
-    const secondUserSet = new Set(secondUserGoalIds);
-    const unionSet = firstUserSet.union(secondUserSet);
-    const intersectionSet = firstUserSet.intersection(secondUserSet);
-    return intersectionSet.size / unionSet.size;
 }
 
 // Uses the five metrics above and their respective weights to calculate overall compatibility score
 const calculateOverallCompatibilityScore = async (firstUserId, secondUserId, fetchData) => {
+    const scores = [];
     const personalityScore = await calculatePairPersonalityScore(firstUserId, secondUserId, fetchData);
-    const locationScore = await calculateLocationScore(firstUserId, secondUserId, fetchData); 
+    scores.push(personalityScore * ScoreWeights["personality"]);
+    const locationScore = await calculateLocationScore(firstUserId, secondUserId, fetchData);
+    if (locationScore){
+        scores.push(locationScore * ScoreWeights["location"]);
+    } 
     const firstUserSchoolInfo = await fetchData(`user/schoolInfo/${firstUserId}`, "GET");
     const secondUserSchoolInfo = await fetchData(`user/schoolInfo/${secondUserId}`, "GET");
     const classStandingScore = calculateClassStandingScore(firstUserSchoolInfo, secondUserSchoolInfo);
+    if (classStandingScore){
+        scores.push(classStandingScore * ScoreWeights["class_standing"]);
+    }
     const schoolScore = calculateSchoolScore(firstUserSchoolInfo, secondUserSchoolInfo);
+    if (schoolScore){
+        scores.push(schoolScore * ScoreWeights["school"]);
+    }
     const goalsScore = await calculateGoalsScore(firstUserId, secondUserId, fetchData);
-    return (
-        (personalityScore * ScoreWeights["personality"]) + 
-        (locationScore * ScoreWeights["location"]) + 
-        (classStandingScore * ScoreWeights["class_standing"]) + 
-        (schoolScore * ScoreWeights["school"]) + 
-        (goalsScore * ScoreWeights["goals"])
-    );
+    if (goalsScore){
+        scores.push(goalsScore * ScoreWeights["goals"]);
+    }
+    const overallScore = scores.reduce((a, b) => {
+        return a + b
+    }, 0);
+    return overallScore;
 }
 
 const CompatibilityScore = async (firstUserId, secondUserId, fetchData) => {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -8,7 +8,7 @@ const prisma = new PrismaClient();
 router.post('/signup', async (req, res) => {
     const {name, username, password, preferred_start_time, preferred_end_time, school, latitude, longitude, class_standing} = req.body
     try {
-        if (!username || !password || !name || !preferred_start_time || !preferred_end_time || !school || !latitude || !longitude || !class_standing) {
+        if (!username || !password || !name || !preferred_start_time || !preferred_end_time) {
             return res.status(400).json({error: "All input fields are required."})
         }
         


### PR DESCRIPTION
## Description

- Allows users to create an account without inputting all of the metrics in the Sign Up form.
- Proportionally redistributes the weights of each metric based on how many metrics were inputted by the user so that the weights of the available metrics will always equal 1.
- Calculates the group compatibility score of each study group even if there are users that didn't fill out all of the metrics/variables.
- In the next PR, I will rank the Group Cards by compatibility and clearly recommend a study group for each class to the user.

## Milestones
This works towards Milestone 7, which is that users can be matched into study groups based on a compatibility score (technical challenge 1).

## Resources

## Test Plan
The user Monica Coira is missing the school and location metrics but the group compatibility score was still calculated with redistributed weights:
<img width="1728" height="937" alt="Screenshot 2025-07-16 at 4 23 51 PM" src="https://github.com/user-attachments/assets/6adbfb1e-bbc7-4060-95d5-b1ea4376adbb" />
Besides testing basic functionality, these are the corner cases I tested:

- Created users with three, two, one, and no missing metrics to ensure that the weight of each available metric is redistributed properly in every case so that all the weights equal 1.
- Created two users with 4 identical metrics but one of the users is missing a metric to ensure that their compatibility score remains 1 because the missing metric is not penalized.
- Manually calculated the new weights for each metric for multiple users to ensure that the algorithm returns the correct weights and compatibility scores.
- Verified that the group compatibility scores of groups where all users have values for all metrics remain the same from the last PR because the weight of each metric has remained the same.