### PR TITLE
Recommend Study Groups Per Class

### DIFF
--- a/client/src/components/GroupCard.jsx
+++ b/client/src/components/GroupCard.jsx
@@ -1,9 +1,11 @@
 import '../styles.css'
+import Pill from './Pill'
 
 // Contains the information for an individual study group
-const GroupCard = ({className, dayOfWeek, time, users, groupCompatibilityScore}) => {
+const GroupCard = ({className, dayOfWeek, time, users, groupCompatibilityScore, recommended}) => {
     return (
         <div className="group-card">
+            {recommended && <div className="recommended-text">Recommended</div>}
             <h3 className="group-card-title">{className}</h3>
             <p className="group-card-day">{dayOfWeek}</p>
             <p className="group-card-time">{time}</p>
@@ -15,7 +17,7 @@ const GroupCard = ({className, dayOfWeek, time, users, groupCompatibilityScore})
                     )
                 })}
             </div>
-            <p className="group-compatibility">Group Compatibility Score: {groupCompatibilityScore}</p>
+            {groupCompatibilityScore !== null && <Pill groupScore={groupCompatibilityScore}/>}
             <div className="group-card-buttons">
                 <button className="buttons">Accept</button>
                 <button className="buttons">Reject</button>

--- a/client/src/components/GroupList.jsx
+++ b/client/src/components/GroupList.jsx
@@ -9,6 +9,7 @@ const GroupList = ({data, user, existingGroups, getClassName, getUserName, fetch
     const GENERIC_DATE = `2025-07-01T`;
     const [userExistingGroups, setUserExistingGroups] = useState([]);
     const [groupScores, setGroupScores] = useState(0);
+    let previousClasses = [];
 
     const getExistingGroupInfo = (groupId) => {
         for (const group of existingGroups){
@@ -77,15 +78,31 @@ const GroupList = ({data, user, existingGroups, getClassName, getUserName, fetch
         )
     }
 
+    const filteredUserGroups = userExistingGroups.filter((obj) => obj.user_id == user.id);
+    const sortedByCompatibilityGroups = filteredUserGroups.sort((a,b) => {
+        return groupScores[b.existing_group_id] - groupScores[a.existing_group_id];
+    })
+
     return (
         <main>
             <div className="group-list-container">
                 {
-                    userExistingGroups.map(obj => {
+                    sortedByCompatibilityGroups.map(obj => {
                         if (user) {
                             if (obj.user_id == user.id){
                                 const groupInfo = getExistingGroupInfo(obj.existing_group_id);
                                 const className = getClassName(groupInfo.class_id);
+                                let recommendedCard = false;
+                                let previousClassCount = 0;
+                                previousClasses.map((c) => {
+                                    if (className === c){
+                                        previousClassCount++;
+                                    }
+                                })
+                                if (previousClassCount === 0){
+                                    recommendedCard = true;
+                                }
+                                previousClasses.push(className);
                                 const dayOfWeek = Object.keys(WeekDays)[groupInfo.day_of_week - 1];
                                 const time = groupInfo.start_time + " - " + groupInfo.end_time;
                                 const groupMembers = getGroupMembers(obj.existing_group_id)
@@ -95,7 +112,7 @@ const GroupList = ({data, user, existingGroups, getClassName, getUserName, fetch
                                 }
                                 const groupScore = groupScores[obj.existing_group_id] ? groupScores[obj.existing_group_id] : null;
                                 return (
-                                    <GroupCard key={obj.id} className={className} dayOfWeek={dayOfWeek} time={time} users={userNames} groupCompatibilityScore={groupScore}/>
+                                    <GroupCard key={obj.id} className={className} dayOfWeek={dayOfWeek} time={time} users={userNames} groupCompatibilityScore={groupScore} recommended={recommendedCard}/>
                                 )
                             }
                         }

--- a/client/src/components/Pill.jsx
+++ b/client/src/components/Pill.jsx
@@ -1,0 +1,14 @@
+import '../styles.css'
+
+const Pill = ({groupScore}) => {
+    const HIGH_COMPATIBILITY_THRESHOLD = 0.75;
+    const MEDIUM_COMPATIBILITY_THRESHOLD = 0.50;
+    const pillColor = parseFloat(groupScore) >= HIGH_COMPATIBILITY_THRESHOLD ? "pill-component-green" : (parseFloat(groupScore) >= MEDIUM_COMPATIBILITY_THRESHOLD ? "pill-component-yellow" : "pill-component-red");
+    return (
+        <div className="pill-component" id={pillColor}>
+            <div>Group Compatibility: {groupScore}</div>
+        </div>
+    )
+}
+
+export default Pill;

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -440,6 +440,16 @@ button:focus-visible {
     padding-bottom: 30px;
 }
 
+.recommended-text {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    border: 1px solid black;
+    font-weight: 600;
+    background-color: #ececec;
+}
+
 .group-card-buttons {
     display: flex;
     justify-content: center;
@@ -449,6 +459,7 @@ button:focus-visible {
 
 .group-card:hover {
     transform: scale(1.03) translateY(-2px);
+    cursor: pointer;
 }
 
 .group-card-title {
@@ -470,4 +481,26 @@ button:focus-visible {
     margin-bottom: 20px;
 }
 
+.pill-component {
+    border-radius: 8px;
+    font-size: 0.8em;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    transition: border-color 0.25s;
+    padding: 2px;
+    margin-bottom: 20px;
+}
+
+#pill-component-green {
+    background-color: #adebb3;
+}
+
+#pill-component-yellow {
+    background-color: #ffee8c;
+}
+
+#pill-component-red {
+    background-color: #ff7f7f;
+}
 


### PR DESCRIPTION
## Description

- Sorts study groups by compatibility score in descending order.
- Recommends one study group per class to the user based on the group compatibility scores.
- In the next PR, I will allow the user to generate study goals for each group using Gemini API.

## Milestones
This works towards Milestone 7, which is that users can be matched into study groups based on a compatibility score (technical challenge 1).

## Resources

## Test Plan
<img width="1728" height="944" alt="Screenshot 2025-07-17 at 12 36 19 PM" src="https://github.com/user-attachments/assets/000cedc6-fb3e-4e99-9210-422033152098" />

- Created groups with identical group compatibility scores to ensure that the study groups are still properly sorted in descending order on the Groups Page.
- Created multiple groups for the same class to ensure that, for each class, only the group with the highest compatibility score is recommended to the user.
- Created groups with high, medium, and low compatibility to ensure that the correct visuals are displayed for each category.
