### PR TITLE
Accept and Reject Study Groups

### DIFF
--- a/client/src/components/GroupCard.jsx
+++ b/client/src/components/GroupCard.jsx
@@ -1,35 +1,53 @@
 import '../styles.css'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Pill from './Pill'
 import CreateStudyGoals from './CreateStudyGoals'
 import StudyGoalsModal from './StudyGoalsModal'
 
 // Contains the information for an individual study group
-const GroupCard = ({className, dayOfWeek, time, users, groupCompatibilityScore, recommended}) => {
+const GroupCard = ({className, dayOfWeek, time, users, groupCompatibilityScore, isCardRecommended, handleUpdateGroupStatus, groupId}) => {
     const [studyGoalsModalIsOpen, setStudyGoalsModalIsOpen] = useState(false);
+    const [recommended, setRecommended] = useState();
 
     const onModalClose = () => {
         setStudyGoalsModalIsOpen(false);
     }
 
+    const handleAcceptGroup = () => {
+        handleUpdateGroupStatus(groupId, "accepted");
+    }
+
+    const handleRejectGroup = () => {
+        handleUpdateGroupStatus(groupId, "rejected");
+    }
+
+    useEffect(() => {
+        let recommendedStatus = false;
+        isCardRecommended(groupId).then((result) => {
+            recommendedStatus = result;
+        }).then(() => {
+            setRecommended(recommendedStatus);
+        })
+    }, [])
+
     return (
         <div className={studyGoalsModalIsOpen ? "group-card" : "hover-group-card"}>
             {recommended && <div className="recommended-text">Recommended</div>}
             <h3 className="group-card-title">{className}</h3>
-            <p className="group-card-day">{dayOfWeek}</p>
-            <p className="group-card-time">{time}</p>
+            <div className="group-card-day">{dayOfWeek}</div>
+            <div className="group-card-time">{time}</div>
             <h5 className="group-card-users">Members:</h5>
             <div className="group-card-members">
                 {users.map((item, index) => {
                     return (
-                        <p className="group-card-member" key={index}>{item}</p>
+                        <div className="group-card-member" key={index}>{item}</div>
                     )
                 })}
             </div>
             {groupCompatibilityScore !== null && <Pill groupScore={groupCompatibilityScore}/>}
             <div className="group-card-buttons">
-                <button className="buttons">Accept</button>
-                <button className="buttons">Reject</button>
+                <button className="buttons" onClick={handleAcceptGroup}>Accept</button>
+                <button className="buttons" onClick={handleRejectGroup}>Reject</button>
             </div>
             <CreateStudyGoals setStudyGoalsModalIsOpen={setStudyGoalsModalIsOpen}/>
             <StudyGoalsModal studyGoalsModalIsOpen={studyGoalsModalIsOpen} onModalClose={onModalClose} className={className}/>

--- a/client/src/components/GroupList.jsx
+++ b/client/src/components/GroupList.jsx
@@ -5,11 +5,14 @@ import { useEffect, useState } from 'react'
 import CompatibilityScore from '../utils/CompatibilityScore'
 
 // Displays all of a user's study groups in a grid format
-const GroupList = ({data, user, existingGroups, getClassName, getUserName, fetchData}) => {
+const GroupList = ({data, user, existingGroups, getClassName, getUserName, fetchData, handleUpdateGroupStatus, currentStatus}) => {
     const GENERIC_DATE = `2025-07-01T`;
     const [userExistingGroups, setUserExistingGroups] = useState([]);
-    const [groupScores, setGroupScores] = useState(0);
+    const [groupScores, setGroupScores] = useState({});
+    const [statusGroups, setStatusGroups] = useState([]);
+    const groupsByStatus = [];
     let previousClasses = [];
+    const POSSIBLE_STATUS = ["available", "accepted", "rejected"];
 
     const getExistingGroupInfo = (groupId) => {
         for (const group of existingGroups){
@@ -62,15 +65,84 @@ const GroupList = ({data, user, existingGroups, getClassName, getUserName, fetch
         setGroupScores(compatibilityScores);
     }
 
+    const groupByStatus = async () => {
+        const filteredUserGroups = userExistingGroups.filter((obj) => obj.user_id == user.id);
+        for (const group of filteredUserGroups){
+            if (!groupsByStatus[group.status]){
+                groupsByStatus[group.status] = [];
+            }
+            groupsByStatus[group.status].push(group);
+        }
+        for (const status of POSSIBLE_STATUS){
+            groupsByStatus[status]?.sort((a,b) => {
+                return groupScores[b.existing_group_id] - groupScores[a.existing_group_id];
+            })
+        }
+        setStatusGroups(groupsByStatus);
+    }
+
+    const handleRecommend = async (groupId) => {
+        const recommendedGroup = await fetchData(`group/userExistingGroup/recommend/${groupId}/`, "PUT");
+    }
+
+    const recommendGroups = async () => {
+        let alreadyRecommended = false;
+        if (userExistingGroups.length !== 0){
+            userExistingGroups.map((obj) => {
+                if (obj.recommended){
+                    alreadyRecommended = true;
+                }
+            })
+            if (!alreadyRecommended){
+                userExistingGroups.map((obj) => {
+                    if (user) {
+                        if (obj.user_id == user.id){
+                            const groupInfo = getExistingGroupInfo(obj.existing_group_id);
+                            const className = getClassName(groupInfo.class_id);
+                            let previousClassCount = 0;
+                            previousClasses.map((c) => {
+                                if (className === c){
+                                    previousClassCount++;
+                                }
+                            })
+                            if (previousClassCount === 0){
+                                handleRecommend(obj.id);
+                            }
+                            previousClasses.push(className);
+                        }
+                    }
+                })
+            }
+        }
+    }
+
+    const isCardRecommended = async (objId) => {
+        const isRecommended = await fetchData(`group/userExistingGroup/recommend/${objId}/`, "GET");
+        return isRecommended;
+    }
+
     useEffect(() => {
         setUserExistingGroups(data);
     }, [data])
 
-    useEffect(() => {
+    const loadGroupScores = async () => {
         if (user){
-            calculateAllGroupScores();
+            await calculateAllGroupScores();
         }
+    }
+
+    const loadGroupsByStatus = async () => {
+        await groupByStatus();
+    }
+
+    useEffect(() => {
+        loadGroupScores();
+        recommendGroups();
     }, [userExistingGroups, user])
+
+    useEffect(() => {
+        loadGroupsByStatus();
+    }, [groupScores, currentStatus])
 
     if (!data || !user){
         return (
@@ -78,46 +150,44 @@ const GroupList = ({data, user, existingGroups, getClassName, getUserName, fetch
         )
     }
 
-    const filteredUserGroups = userExistingGroups.filter((obj) => obj.user_id == user.id);
-    const sortedByCompatibilityGroups = filteredUserGroups.sort((a,b) => {
-        return groupScores[b.existing_group_id] - groupScores[a.existing_group_id];
-    })
+    const displayGroupCard = (obj) => {
+        if (user) {
+            if (obj.user_id == user.id){
+                const groupInfo = getExistingGroupInfo(obj.existing_group_id);
+                const className = getClassName(groupInfo.class_id);
+                const dayOfWeek = Object.keys(WeekDays)[groupInfo.day_of_week - 1];
+                const time = groupInfo.start_time + " - " + groupInfo.end_time;
+                const groupMembers = getGroupMembers(obj.existing_group_id)
+                let userNames = []
+                for (const member of groupMembers){
+                    userNames.push(getUserName(member))
+                }
+                const groupScore = groupScores[obj.existing_group_id] ? groupScores[obj.existing_group_id] : null;
+                return (
+                    <GroupCard key={obj.id} className={className} dayOfWeek={dayOfWeek} time={time} users={userNames} groupCompatibilityScore={groupScore} isCardRecommended={isCardRecommended} handleUpdateGroupStatus={handleUpdateGroupStatus} groupId={obj.id}/>
+                )
+            }
+        }
+    }
 
     return (
         <main>
             <div className="group-list-container">
-                {
-                    sortedByCompatibilityGroups.map(obj => {
-                        if (user) {
-                            if (obj.user_id == user.id){
-                                const groupInfo = getExistingGroupInfo(obj.existing_group_id);
-                                const className = getClassName(groupInfo.class_id);
-                                let recommendedCard = false;
-                                let previousClassCount = 0;
-                                previousClasses.map((c) => {
-                                    if (className === c){
-                                        previousClassCount++;
-                                    }
-                                })
-                                if (previousClassCount === 0){
-                                    recommendedCard = true;
+                {POSSIBLE_STATUS.map((status) => {
+                    return (
+                        <div key={status}>
+                            <h3>{status.charAt(0).toLocaleUpperCase() + status.slice(1)} Groups</h3>
+                            <div className="group-list-section">
+                                {
+                                    statusGroups && statusGroups[status] &&
+                                    statusGroups[status].map(obj => {
+                                        return displayGroupCard(obj)
+                                    })
                                 }
-                                previousClasses.push(className);
-                                const dayOfWeek = Object.keys(WeekDays)[groupInfo.day_of_week - 1];
-                                const time = groupInfo.start_time + " - " + groupInfo.end_time;
-                                const groupMembers = getGroupMembers(obj.existing_group_id)
-                                let userNames = []
-                                for (const member of groupMembers){
-                                    userNames.push(getUserName(member))
-                                }
-                                const groupScore = groupScores[obj.existing_group_id] ? groupScores[obj.existing_group_id] : null;
-                                return (
-                                    <GroupCard key={obj.id} className={className} dayOfWeek={dayOfWeek} time={time} users={userNames} groupCompatibilityScore={groupScore} recommended={recommendedCard}/>
-                                )
-                            }
-                        }
-                    })
-                }
+                            </div>
+                        </div> 
+                    )
+                })}
             </div>
         </main>
     )

--- a/client/src/components/StudyGoalsModal.jsx
+++ b/client/src/components/StudyGoalsModal.jsx
@@ -35,10 +35,10 @@ const StudyGoalsModal = ({studyGoalsModalIsOpen, onModalClose, className}) => {
                 <div className="new-group-modal-close-button">
                     <span className="close" onClick={handleModalClose}>&times;</span>
                 </div>
-                <h3>Generate Study Goals For Your Group</h3>
+                <h3>Generate Study Goals for {className}</h3>
                 <form onSubmit={handleNewGoalsSubmit} className="new-group-modal-form">
-                    <label htmlFor="resources-input">Input class resources here:</label>
-                    <input type="text" value={inputValue} onChange={handleInputChange}></input>
+                    <label htmlFor="resources-input">Input Class Resources:</label>
+                    <textarea value={inputValue} rows={5} onChange={handleInputChange} placeholder="Please input class resources like notes, syllabi, flashcards, etc."></textarea>
                     <div className="new-group-modal-buttons">
                         <button type="submit" className="new-group-modal-submit">Submit</button>
                     </div>
@@ -47,10 +47,7 @@ const StudyGoalsModal = ({studyGoalsModalIsOpen, onModalClose, className}) => {
                     <h4>Main Study Goals:</h4>
                     {
                         !loading && mainStudyGoals === "" && 
-                        <div>
-                            <div>There are no available study goals for this group yet.</div>
-                            <div>Please input class resources like notes, syllabi, flashcards, etc.</div>
-                        </div>
+                        <div>There are no available study goals for this group yet.</div>
                     }
                     {loading && 
                         <LoadingIndicator loading={loading} />

--- a/client/src/pages/GroupsPage.jsx
+++ b/client/src/pages/GroupsPage.jsx
@@ -17,6 +17,7 @@ const GroupsPage = () => {
     const [allUsers, setAllUsers] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState("");
+    const [currentStatus, setCurrentStatus] = useState({});
 
     const fetchData = async (endpoint, method = "GET", headers, credentials = "same-origin", body = null) => {
         try {
@@ -80,7 +81,7 @@ const GroupsPage = () => {
 
     useEffect(() => {
         loadData();
-    }, [])
+    }, [currentStatus])
 
     const getClassName = (classId) => {
         for (const c of classList){
@@ -103,6 +104,14 @@ const GroupsPage = () => {
         }
     }
 
+    const handleUpdateGroupStatus = async (groupId, updatedStatus) => {
+        const newStatus = {
+            status: updatedStatus
+        }
+        const updatedGroup = await fetchData(`group/userExistingGroup/${groupId}/`, "PUT", {"Content-Type": "application/json"}, "same-origin", JSON.stringify(newStatus));
+        setCurrentStatus({groupId, updatedStatus});
+    }
+
     return (
         <div className="groups-page">
             <header className="groups-page-header">
@@ -116,7 +125,7 @@ const GroupsPage = () => {
                 {isLoading ? (
                     <div>Loading...</div>
                 ) : (
-                    <GroupList data={userExistingGroups} user={user} existingGroups={existingGroups} getClassName={getClassName} getUserName={getUserName} fetchData={fetchData}/>
+                    <GroupList data={userExistingGroups} user={user} existingGroups={existingGroups} getClassName={getClassName} getUserName={getUserName} fetchData={fetchData} handleUpdateGroupStatus={handleUpdateGroupStatus} currentStatus={currentStatus}/>
                 )}
                 {error && (
                     <p>{error}</p>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -331,7 +331,7 @@ button:focus-visible {
 }
 
 #create-group-button {
-    margin-bottom: 40px;
+    margin-bottom: 30px;
 }
 
 .new-group-modal {
@@ -377,7 +377,7 @@ button:focus-visible {
     flex-direction: column;
 }
 
-.new-group-modal-form input {
+.new-group-modal-form input, .new-group-modal-form textarea {
     padding: 15px;
 }
 
@@ -419,11 +419,15 @@ button:focus-visible {
 }
 
 .group-list-container {
-    gap: 15px;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
     padding-bottom: 80px;
+    flex-direction: column;
+}
+
+.group-list-section {
+    display: flex;
 }
 
 .group-card, .hover-group-card {
@@ -438,6 +442,7 @@ button:focus-visible {
     box-shadow: 0 12px 20px rgba(0,0,0,0.15);
     border-radius: 10px;
     padding-bottom: 30px;
+    gap: 5px;
 }
 
 .recommended-text {

--- a/server/prisma/migrations/20250718074323_update_user_existing_group_table/migration.sql
+++ b/server/prisma/migrations/20250718074323_update_user_existing_group_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "userExistingGroups" ADD COLUMN     "status" TEXT NOT NULL DEFAULT 'available';

--- a/server/prisma/migrations/20250718191450_update_user_existing_group_table/migration.sql
+++ b/server/prisma/migrations/20250718191450_update_user_existing_group_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "userExistingGroups" ADD COLUMN     "recommended" BOOLEAN NOT NULL DEFAULT false;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -100,6 +100,8 @@ model UserExistingGroup {
   id                  Int              @id @default(autoincrement())
   user_id             Int
   existing_group_id   Int
+  status              String           @default("available")
+  recommended         Boolean          @default(false)
   user                User             @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   existing_group      ExistingGroup    @relation(fields: [existing_group_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 

--- a/server/routes/GroupRoutes.js
+++ b/server/routes/GroupRoutes.js
@@ -29,6 +29,14 @@ router.post('/userExistingGroup', async (req, res) => {
     res.json(newUserExistingGroupData);
 })
 
+router.get('/userExistingGroup/recommend/:groupId', async (req, res) => {
+    const groupId = parseInt(req.params.groupId)
+    const isRecommended = await prisma.userExistingGroup.findUnique({
+        where: {id: parseInt(groupId)},
+    });
+    res.json(isRecommended.recommended);
+})
+
 router.get('/userExistingGroup/:userId/:groupId', async (req, res) => {
     const userId = parseInt(req.params.userId)
     const groupId = parseInt(req.params.groupId)
@@ -49,6 +57,29 @@ router.get('/existingGroup', async (req, res) => {
 router.get('/userExistingGroup', async (req, res) => {
     const userExistingGroups = await prisma.userExistingGroup.findMany();
     res.json(userExistingGroups);
+})
+
+router.put('/userExistingGroup/recommend/:groupId', async (req, res) => {
+    const groupId = parseInt(req.params.groupId);
+    const updatedGroupData = await prisma.userExistingGroup.update({
+        where: {id: parseInt(groupId)},
+        data: {
+            recommended: true
+        }
+    })
+    res.json(updatedGroupData);
+})
+
+router.put('/userExistingGroup/:groupId', async (req, res) => {
+    const groupId = parseInt(req.params.groupId);
+    const {status} = req.body;
+    const updatedGroupData = await prisma.userExistingGroup.update({
+        where: {id: parseInt(groupId)},
+        data: {
+            status
+        }
+    })
+    res.json(updatedGroupData);
 })
 
 module.exports = router


### PR DESCRIPTION
## Description

- Implements three different sections to separate study groups based on status: Available, Accepted, and Rejected.
- Allows users to accept a group by clicking the "Accept" button and moves this group into the Accepted Groups section.
- Allows users to reject a group by clicking the "Reject" button and moves this group into the Rejected Groups section.
- Gives users flexibility by allowing them to reject a group that has already been accepted and accept a group that has already been rejected.
- Recommends the group with the highest compatibility score for each class, regardless of the status of the group.
- In the next PR, I will remove the user from a group when they reject it and add the user back into the group if they decide to accept it later on.

## Milestones
This works towards Milestone 8, which is that users can accept/reject the study groups they are matched into.

## Resources

## Test Plan

https://github.com/user-attachments/assets/750af4ef-a1e5-4c32-94ee-cc77662eaf5a

Besides testing basic functionality, these are the corner cases I tested:

- Accepted and rejected various groups to ensure that all the groups are moved into the correct section without needing to refresh the page.
- Randomly placed the groups in different sections to ensure that the groups in each section remain sorted by compatibility score in descending order.
- Accepted and then immediately rejected the same study group to ensure that the user has the flexibility of changing their mind and moving around their group decisions.
- Shuffled the order of the study groups to ensure that only the groups with the highest compatibility score for each class would remain marked as "Recommended."