### PR TITLE
Store and Display Main Study Goals

### DIFF
--- a/client/src/components/GoalsGenerator.jsx
+++ b/client/src/components/GoalsGenerator.jsx
@@ -1,13 +1,15 @@
 import { GoogleGenAI } from "@google/genai";
 import { GEMINI_API_KEY } from "../utils/apiConfig";
 
-const GoalsGenerator = async (className, userResource) => {
+// Generates 5 study goals using class name, resources inputted by the current user, and previous study goals generated for the group (if any)
+const GoalsGenerator = async (className, userResource, previousGoals) => {
     const ai = new GoogleGenAI({apiKey: GEMINI_API_KEY});
     const response = await ai.models.generateContent({
         model: "gemini-2.5-flash",
         contents: `A study group of college students meets every week to study for the ${className} university course. 
         Generate five main study goals for this study group to focus on during their meetings that highlight the most important topics and themes that must be covered for this class.
-        Use this resource to help compile the five main study goals for the class: ${userResource}. Number the goals in a list from 1 to 5 and have each goal be short and concise, only 1 sentence per goal.`,
+        Use this resource to help compile the five main study goals for the class: ${userResource}. Number the goals in a list from 1 to 5 and have each goal be short and concise, only 1 sentence per goal.
+        If ${previousGoals} is not null, use these study goals, as well the new resource, to generate the new five main study goals.`,
     });
     return (
         response.text

--- a/client/src/components/GroupCard.jsx
+++ b/client/src/components/GroupCard.jsx
@@ -5,7 +5,7 @@ import CreateStudyGoals from './CreateStudyGoals'
 import StudyGoalsModal from './StudyGoalsModal'
 
 // Contains the information for an individual study group
-const GroupCard = ({className, dayOfWeek, time, users, groupCompatibilityScore, isCardRecommended, handleUpdateGroupStatus, groupId, recommendationsChangedAt}) => {
+const GroupCard = ({className, dayOfWeek, time, users, groupCompatibilityScore, isCardRecommended, handleUpdateGroupStatus, groupId, recommendationsChangedAt, fetchData, existingId}) => {
     const [studyGoalsModalIsOpen, setStudyGoalsModalIsOpen] = useState(false);
     const [recommended, setRecommended] = useState();
 
@@ -50,7 +50,7 @@ const GroupCard = ({className, dayOfWeek, time, users, groupCompatibilityScore, 
                 <button className="buttons" onClick={handleRejectGroup}>Reject</button>
             </div>
             <CreateStudyGoals setStudyGoalsModalIsOpen={setStudyGoalsModalIsOpen}/>
-            <StudyGoalsModal studyGoalsModalIsOpen={studyGoalsModalIsOpen} onModalClose={onModalClose} className={className}/>
+            <StudyGoalsModal studyGoalsModalIsOpen={studyGoalsModalIsOpen} onModalClose={onModalClose} className={className} fetchData={fetchData} groupId={existingId}/>
         </div>
     )
 }

--- a/client/src/components/GroupList.jsx
+++ b/client/src/components/GroupList.jsx
@@ -177,7 +177,7 @@ const GroupList = ({data, user, existingGroups, getClassName, getUserName, fetch
                 }
                 const groupScore = groupScores[obj.existing_group_id] ? groupScores[obj.existing_group_id] : null;
                 return (
-                    <GroupCard key={obj.id} className={className} dayOfWeek={dayOfWeek} time={time} users={userNames} groupCompatibilityScore={groupScore} isCardRecommended={isCardRecommended} handleUpdateGroupStatus={handleUpdateGroupStatus} groupId={obj.id} recommendationsChangedAt={recommendationsChangedAt}/>
+                    <GroupCard key={obj.id} className={className} dayOfWeek={dayOfWeek} time={time} users={userNames} groupCompatibilityScore={groupScore} isCardRecommended={isCardRecommended} handleUpdateGroupStatus={handleUpdateGroupStatus} groupId={obj.id} recommendationsChangedAt={recommendationsChangedAt} fetchData={fetchData} existingId={obj.existing_group_id}/>
                 )
             }
         }

--- a/server/prisma/migrations/20250719231314_update_existing_group_table/migration.sql
+++ b/server/prisma/migrations/20250719231314_update_existing_group_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "existingGroups" ADD COLUMN     "study_goals" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -91,6 +91,7 @@ model ExistingGroup {
   day_of_week           Int
   start_time            String
   end_time              String
+  study_goals           String?
   user_existing_groups  UserExistingGroup[] 
 
   @@map("existingGroups")

--- a/server/routes/GroupRoutes.js
+++ b/server/routes/GroupRoutes.js
@@ -59,6 +59,31 @@ router.get('/userExistingGroup', async (req, res) => {
     res.json(userExistingGroups);
 })
 
+router.put('/existingGroup/:groupId', async (req, res) => {
+    const groupId = parseInt(req.params.groupId);
+    const {study_goals} = req.body;
+    const updatedGroupData = await prisma.existingGroup.update({
+        where: {id: parseInt(groupId)},
+        data: {
+            study_goals
+        }
+    })
+    res.json(study_goals);
+})
+
+router.get('/existingGroup/:groupId', async (req, res) => {
+    const groupId = parseInt(req.params.groupId)
+    const existingStudyGoals = await prisma.existingGroup.findUnique({
+        where: {
+            id: parseInt(groupId),
+        },
+    });
+    if (!existingStudyGoals.study_goals){
+        res.json(null);
+    }
+    res.json(existingStudyGoals.study_goals);
+})
+
 router.put('/userExistingGroup/recommend/:groupId', async (req, res) => {
     const groupId = parseInt(req.params.groupId);
     const updatedGroupData = await prisma.userExistingGroup.update({


### PR DESCRIPTION
## Description

- Stores the study goals generated for each group in the database to reduce the number of calls made to Gemini API.
- Displays existing study goals for each group to all the users in that group.
- Allows users to input their own resources, even if study goals have already been generated, and uses these new resources, along with the old ones, to update the study goals.
- In the next PR, I will continue implementing the accept/reject group functionality by removing a user from a group when they reject it and adding the user back if they decide to accept the group later on.

## Milestones
This works towards Milestone 9, which is that the user can generate main study goals for their groups using Gemini API.

## Resources

## Test Plan

https://github.com/user-attachments/assets/05b15271-2f11-4c39-b2a8-ab683f126382


- Inputted new resources to a group that already has study goals to ensure that the new resource, as well as the old study goals, are both used to generate updated study goals.
- Opened the study goals for a specific group through the accounts of multiple users to ensure that the goals are visible to all members of a group.
- Refreshed the page and logged out and back into an account to ensure that the study goals are still displayed for each group.
- Generated study goals using different types of resources such as syllabi, flashcards, and sections of textbooks to ensure that study goals can be generated using any resource inputted by the user.