### PR TITLE
Calculate Compatibility Score Using User Favorites

### DIFF
--- a/client/src/components/GroupCard.jsx
+++ b/client/src/components/GroupCard.jsx
@@ -7,7 +7,7 @@ import MemberCard from './MemberCard'
 import Tooltip from './Tooltip'
 
 // Contains the information for an individual study group
-const GroupCard = ({className, dayOfWeek, time, users, groupCompatibilityScore, isCardRecommended, handleUpdateGroupStatus, groupId, recommendationsChangedAt, fetchData, existingId, status, user}) => {
+const GroupCard = ({className, dayOfWeek, time, users, groupCompatibilityScore, isCardRecommended, handleUpdateGroupStatus, groupId, recommendationsChangedAt, fetchData, existingId, status, user, handleFavorited}) => {
     const [studyGoalsModalIsOpen, setStudyGoalsModalIsOpen] = useState(false);
     const [recommended, setRecommended] = useState();
     const [userInformation, setUserInformation] = useState([]);
@@ -61,7 +61,7 @@ const GroupCard = ({className, dayOfWeek, time, users, groupCompatibilityScore, 
                     if (userInformation[item]){
                         return (
                             <MemberCard 
-                                key={index} name={userInformation[item][0].name} email={userInformation[item][0].email} phoneNumber={userInformation[item][0].phone_number} profilePicture={userInformation[item][0].profile_picture} fetchData={fetchData} id={userInformation[item][0].id} user={user}
+                                key={index} name={userInformation[item][0].name} email={userInformation[item][0].email} phoneNumber={userInformation[item][0].phone_number} profilePicture={userInformation[item][0].profile_picture} fetchData={fetchData} id={userInformation[item][0].id} user={user} handleFavorited={handleFavorited}
                             />
                         )
                     }

--- a/client/src/components/GroupList.jsx
+++ b/client/src/components/GroupList.jsx
@@ -15,6 +15,7 @@ const GroupList = ({data, user, existingGroups, getClassName, getUserName, fetch
     const [recommendationsChangedAt, setRecommendationsChangedAt] = useState(Date.now());
     const POSSIBLE_STATUS = ["available", "accepted", "rejected"];
     const [isLoading, setIsLoading] = useState(true);
+    const [wasFavorited, setWasFavorited] = useState(false);
 
     const getExistingGroupInfo = (groupId) => {
         for (const group of existingGroups){
@@ -131,6 +132,10 @@ const GroupList = ({data, user, existingGroups, getClassName, getUserName, fetch
         return isRecommended;
     }
 
+    const handleFavorited = () => {
+        setWasFavorited(prev => !prev);
+    }
+
     useEffect(() => {
         setUserExistingGroups(data);
     }, [data])
@@ -147,7 +152,7 @@ const GroupList = ({data, user, existingGroups, getClassName, getUserName, fetch
 
     useEffect(() => {
         loadGroupScores();
-    }, [userExistingGroups, user])
+    }, [userExistingGroups, user, wasFavorited])
 
     useEffect(() => {
         loadGroupsByStatus();
@@ -183,7 +188,7 @@ const GroupList = ({data, user, existingGroups, getClassName, getUserName, fetch
                 }
                 const groupScore = groupScores[obj.existing_group_id] ? groupScores[obj.existing_group_id] : null;
                 return (
-                    <GroupCard key={obj.id} className={className} dayOfWeek={dayOfWeek} time={time} users={userNames} groupCompatibilityScore={groupScore} isCardRecommended={isCardRecommended} handleUpdateGroupStatus={handleUpdateGroupStatus} groupId={obj.id} recommendationsChangedAt={recommendationsChangedAt} fetchData={fetchData} existingId={obj.existing_group_id} status={obj.status} user={user}/>
+                    <GroupCard key={obj.id} className={className} dayOfWeek={dayOfWeek} time={time} users={userNames} groupCompatibilityScore={groupScore} isCardRecommended={isCardRecommended} handleUpdateGroupStatus={handleUpdateGroupStatus} groupId={obj.id} recommendationsChangedAt={recommendationsChangedAt} fetchData={fetchData} existingId={obj.existing_group_id} status={obj.status} user={user} handleFavorited={handleFavorited}/>
                 )
             }
         }

--- a/client/src/components/MemberCard.jsx
+++ b/client/src/components/MemberCard.jsx
@@ -3,10 +3,9 @@ import { useEffect, useState } from 'react';
 import EmptyStar from '/src/images/empty-star.png'
 import YellowStar from '/src/images/yellow-star.png'
 
-const MemberCard = ({name, email, phoneNumber, profilePicture, fetchData, id, user}) => {
+const MemberCard = ({name, email, phoneNumber, profilePicture, fetchData, id, user, handleFavorited}) => {
     const [uploadedProfilePic, setUploadedProfilePic] = useState(null);
     const [isFavorited, setIsFavorited] = useState(false);
-    const [existingFavorites, setExistingFavorites] = useState([]);
     const [favoritedSpecificUser, setFavoritedSpecificUser] = useState([]);
 
     const fetchProfilePicture = async () => {
@@ -17,7 +16,6 @@ const MemberCard = ({name, email, phoneNumber, profilePicture, fetchData, id, us
 
     const handleDisplayFavorites = async () => {
         const favorites = await fetchData(`user/favorite/${user.id}`, "GET");
-        setExistingFavorites(favorites);
         if (favorites && favorites.length !== 0){
             const specificUserFavorites = favorites.filter(userFavorite => userFavorite.favorite_user === id);
             setFavoritedSpecificUser(specificUserFavorites);
@@ -46,6 +44,7 @@ const MemberCard = ({name, email, phoneNumber, profilePicture, fetchData, id, us
             }
             setIsFavorited(true);
         }
+        handleFavorited();
     }
 
     useEffect(() => {
@@ -69,7 +68,7 @@ const MemberCard = ({name, email, phoneNumber, profilePicture, fetchData, id, us
                 <div className="member-card-phone-number">{phoneNumber}</div>
             </div>
             <div className="member-card-info-favorite">
-                <img src={isFavorited ? YellowStar : EmptyStar} width="20" height="20" onClick={handleFavorite} className="favorite-button"/>
+                {user.id !== id && <img src={isFavorited ? YellowStar : EmptyStar} width="20" height="20" onClick={handleFavorite} className="favorite-button"/>}
             </div>
         </div>
     )

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -78,6 +78,10 @@ button:focus-visible {
     width: 100%;
 }
 
+h2 {
+    font-size: 40px;
+}
+
 .home, .profile-page, .groups-page {
     margin: 0;
     padding: 0;
@@ -635,6 +639,7 @@ button:focus-visible {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
+    margin-left: auto;
 }
 
 .tooltip-container {

--- a/client/src/utils/CompatibilityScore.jsx
+++ b/client/src/utils/CompatibilityScore.jsx
@@ -147,9 +147,22 @@ const calculateOverallCompatibilityScore = async (firstUserId, secondUserId, fet
     const filteredScores = scores.map((score) => ({
         score: score.score_value
     }));
-    const overallScore = filteredScores.reduce((a, b) => {
+    let overallScore = filteredScores.reduce((a, b) => {
         return a + b.score
     }, 0);
+    const userFavorites = await fetchData(`user/favorite/${firstUserId}`, "GET");
+    const memberInUserFavorites = userFavorites.filter(userFavorite => userFavorite.favorite_user === secondUserId);
+    const memberFavorites = await fetchData(`user/favorite/${secondUserId}`, "GET");
+    const userInMemberFavorites = memberFavorites.filter(memberFavorite => memberFavorite.favorite_user === firstUserId);
+    if (memberInUserFavorites.length !== 0 && userInMemberFavorites.length !== 0){
+        overallScore += 0.1;
+    }
+    else if (memberInUserFavorites.length !== 0){
+        overallScore += 0.07;
+    }
+    else if (userInMemberFavorites.length !== 0){
+        overallScore += 0.05;
+    }
     return overallScore;
 }
 

--- a/client/src/utils/MatchByAvailability.jsx
+++ b/client/src/utils/MatchByAvailability.jsx
@@ -222,6 +222,20 @@ const findGroupsByAvailability = async (fetchData, stringToTime, sharedUserAvail
             const matchedExistingGroups = filteredExistingGroupsMap.get(groupKey);
             let usersRemaining = [...usersArray];
             if (matchedExistingGroups && usersArray.length !== 0){
+                for (const possibleUser of usersRemaining){
+                    const preferredTimes = await fetchData(`user/preferredTimes/${possibleUser}`, "GET");
+                    let userRemovedCount = 0
+                    for (const matchedGroup of [...matchedExistingGroups]){
+                        if (stringToTime(matchedGroup.end_time) <= stringToTime(preferredTimes.preferred_start_time) || stringToTime(matchedGroup.start_time) >= stringToTime(preferredTimes.preferred_end_time)){
+                            usersRemaining = usersRemaining.filter(user => user !== possibleUser);
+                            userRemovedCount++;
+                        }
+                    }
+                    if (userRemovedCount === filteredExistingGroupsMap.size){
+                        usersRemaining.push(possibleUser);
+                        usersRemaining.sort((a,b) => a - b);
+                    }
+                }
                 for (const group of matchedExistingGroups){
                     if (!group.users){
                         group.users = [];


### PR DESCRIPTION
## Description

- Calculates the overall compatibility score between two users taking into account the 5 previous metrics and user favorites, which are the group members favorited by the user.
- If a user and a group member are mutual favorites (they both have favorited each other), the compatibility score between these users increases by 0.1.
- If a user favorites a group member, the compatibility score between these two users is increased by 0.07.
- If a group member favorites a user, the compatibility score between the user and this member increases by 0.05.
- In the next PR, I will work on the stretch feature that allows users to delete a group.

## Milestones
This works towards Milestone 7, which is that a user can be matched into a group based on compatibility score (technical challenge 1).

## Resources

## Test Plan

https://github.com/user-attachments/assets/b38ca2a4-59bc-4e0b-8d51-be33e98be750

Besides testing basic functionality, these are the corner cases I tested:

- Mutually favorited users from separate accounts to ensure that the compatibility score increases more than if only one user were to favorite the other.
- Unfavorited users to ensure that the compatibility score is recalculated every time user favorites change.
- Favorited users that belong to multiple groups to ensure that they show as favorited on every group card and that the compatibility score of every group that the two users share increases.
- Unfavorited users that belong to multiple groups to ensure that they are shown as unfavorited in all group cards and the compatibility score of the group cards decreases.