### PR TITLE
Reduce Availability Matching Algorithm Time Complexity

### DIFF
--- a/client/src/utils/MatchByAvailability.jsx
+++ b/client/src/utils/MatchByAvailability.jsx
@@ -201,9 +201,9 @@ const splitUsers = (usersArray) => {
 }
 
 // Checks if a group falls within a user's preferred time range
-const isPreferredMatch = (group, preferredTimes, stringToTime) => {
-    const endTime = stringToTime(group.end_time);
-    const startTime = stringToTime(group.start_time);
+const isPreferredMatch = (groupStartTime, groupEndTime, preferredTimes, stringToTime) => {
+    const endTime = stringToTime(groupEndTime);
+    const startTime = stringToTime(groupStartTime);
     const preferredEnd = stringToTime(preferredTimes.preferred_end_time);
     const preferredStart = stringToTime(preferredTimes.preferred_start_time);
     return !(endTime <= preferredStart || startTime >= preferredEnd)
@@ -212,14 +212,19 @@ const isPreferredMatch = (group, preferredTimes, stringToTime) => {
 // Checks if there exists at least one group that falls during the user's preferred time range
 const checkPreferredMatchExists = (preferredTimes, filteredExistingGroupsMap, stringToTime) => {
     let hasPreferredMatch = false;
-    for (const existingGroups of filteredExistingGroupsMap.values()){
-        for (const existingGroup of existingGroups){
-            if (isPreferredMatch(existingGroup, preferredTimes, stringToTime)){
-                hasPreferredMatch = true;
-                break;
-            }
+    const existingGroupsSet = new Set(filteredExistingGroupsMap.values().map((existingGroups) => existingGroups.map(existingGroup => `${existingGroup.start_time}-${existingGroup.end_time}`)));
+    const existingGroupsArray = new Array([...existingGroupsSet]);
+    const preferredGroups = existingGroupsArray.map((existingGroup) => existingGroup.map(group => {
+        const groupTimes = group[0].split('-');
+        const groupStartTime = groupTimes[0];
+        const groupEndTime = groupTimes[1];
+        if (isPreferredMatch(groupStartTime, groupEndTime, preferredTimes, stringToTime)){
+            hasPreferredMatch = true;
+            return (
+                hasPreferredMatch
+            )
         }
-    }
+    }))
     return hasPreferredMatch;
 }
 


### PR DESCRIPTION
## Description

- Reduces the time complexity of the findGroupsByAvailability method by utilizing sets and .map() instead of nested for loops for checking preferred matches.
- Eliminates unnecessary iterations by returning the hasPreferredMatch value immediately if it is found to be true.
- Sorts users after all users have been removed or added to the usersRemaining array to minimize the number of times .sort() is called.
- In the next PR, I will continue working on deploying my app so that users can access it on their devices.

## Milestones
This works towards improving Milestone 6, which is that the user can be matched into study groups based on availability (technical challenge 2).

## Resources

## Test Plan

https://github.com/user-attachments/assets/86a19bad-e18d-4753-b011-32d44fc73634


Besides testing basic functionality, these are the corner cases I tested:

- Ensured that checkPreferredMatchExists correctly returns if there exists at least one group that falls within the user's preferred times for each user.
- Timed this implementation and the previous implementation (done with for loops) to ensure that the current implementation reduces time complexity and the method executes in less time.
- Ensured that the usersRemaining array is only sorted once, right before users are to be matched into groups.