### PR TITLE
Update Study Goals Error Handling

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -458,7 +458,7 @@ h2 {
     gap: 20px;
 }
 
-.new-group-modal-form input, .new-group-modal-form textarea, .new-group-modal-form select {
+.new-group-modal-form input, .new-group-modal-form textarea, .new-group-modal-form select, .event-popup-inputs {
     padding: 15px;
 }
 

--- a/server/routes/GroupRoutes.js
+++ b/server/routes/GroupRoutes.js
@@ -79,7 +79,7 @@ router.get('/existingGroup/:groupId', async (req, res) => {
         },
     });
     if (!existingStudyGoals.study_goals){
-        res.json(null);
+        return res.json(null);
     }
     res.json(existingStudyGoals.study_goals);
 })


### PR DESCRIPTION
## Description

- Removes error message when a user clicks on the View & Generate Study Goals button and there are no existing study goals for the group.
- In the next PR, I will polish my UI to improve user experience.

## Milestones
This works towards improving error handling.

## Resources

## Test Plan

https://github.com/user-attachments/assets/9cc413ad-b227-4ebd-a13c-28ea037713f7

These are the corner cases I tested:

- Clicked on the View & Generate Study Goals button for a group that has no existing study goals to ensure that an Error message does not appear. Instead, the user should only see the message "There are no available study goals for this group yet."
- Clicked on the View & Generate Study Goals button for a group that has existing study goals to ensure that no error message appears and the existing study goals are displayed.